### PR TITLE
feat: Add passwordless deploy key and update secrets

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -42,10 +42,11 @@ jobs:
           switches: -az --delete
           path: frontend/dist/
           remote_path: /home/moodtalk/tocmood/moodtalk-public/static-frontend/
-          remote_host: ${{ secrets.SSH_HOST }}
-          remote_user: ${{ secrets.SSH_USER }}
-          remote_port: ${{ secrets.SSH_PORT }}
-          remote_key: ${{ secrets.SSH_KEY }}
+          remote_host: ${{ secrets.DEPLOY_HOST }}
+          remote_user: ${{ secrets.DEPLOY_USER }}
+          remote_port: ${{ secrets.DEPLOY_PORT }}
+          remote_key: ${{ secrets.DEPLOY_KEY }}
+          rsh: 'ssh -o StrictHostKeyChecking=no'
 
       - name: Purge Cloudflare cache
         run: |


### PR DESCRIPTION
- 생성: CI 전용 비밀번호 없는 ed25519 키 페어
- 서버: 공개키를 authorized_keys에 등록 완료
- 연결: ssh 테스트 성공 확인
- 워크플로우: DEPLOY_* 시크릿으로 변경
- 보안: StrictHostKeyChecking=no 추가 (CI 환경)

테스트 결과: Deploy key test: OK ✅