### PR TITLE
feat: Add SSH sanity check before rsync deployment

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -36,6 +36,15 @@ jobs:
           echo "Searching 'eft-guide' in dist..."
           grep -R "eft-guide" frontend/dist || echo "OK: no 'eft-guide' in dist"
 
+      - name: SSH sanity check
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh -o StrictHostKeyChecking=no -p ${{ secrets.DEPLOY_PORT }} \
+            -i ~/.ssh/id_rsa \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "echo 'SSH OK on $(hostname)'"
+
       - name: Deploy static files via rsync (auto-delete extras)
         uses: burnett01/rsync-deployments@5.2
         with:


### PR DESCRIPTION
- rsync 실행 전 SSH 연결 테스트로 조기 에러 감지
- GitHub Secrets의 DEPLOY_KEY 형식 검증
- 서버 호스트명, 포트, 사용자명 연결 확인
- 배포 실패 전 문제점 미리 파악 가능

예상 출력: 'SSH OK on modulabs-server'