### PR TITLE
Force rebuild: Fix deployment sync issue

### DIFF
--- a/test_deploy.txt
+++ b/test_deploy.txt
@@ -1,2 +1,3 @@
-PWA cache busting deployment - v2.2.0
-Force update service worker cache
+FORCE REBUILD - Fix deployment sync issue
+Clear all caches and rebuild from scratch
+DateTime: 2025-09-27 16:30 KST


### PR DESCRIPTION
Previous deployment failed to sync latest code changes. Bundle still contains old eft-guide routes despite code updates.

Force complete rebuild and cache clear.
