### PR TITLE
Fix: Implement comprehensive deployment sync solution

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -47,10 +47,10 @@ jobs:
             -i ~/.ssh/id_rsa \
             ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "echo 'SSH OK on $(hostname)'"
 
-      - name: Deploy static files via rsync (auto-delete extras)
+      - name: Deploy static files via rsync (hard sync)
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: -az --delete
+          switches: -avzr --delete --omit-dir-times --no-perms --no-owner --no-group
           path: frontend/dist/
           remote_path: /home/moodtalk/tocmood/moodtalk-public/static-frontend/
           remote_host: ${{ secrets.DEPLOY_HOST }}
@@ -61,6 +61,14 @@ jobs:
       - name: Purge Cloudflare cache
         run: |
           curl -sS -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CF_ZONE_ID }}/purge_cache" -H "Authorization: Bearer ${{ secrets.CF_API_TOKEN }}" -H "Content-Type: application/json" --data '{"purge_everything":true}'
+
+      - name: Smoke test (ensure no 'eft-guide' in live bundle)
+        run: |
+          JS=$(curl -sS https://moodtalk.app/ | grep -o '/assets/index-[^"]*\.js' | head -1)
+          echo "Live JS: $JS"
+          curl -sS "https://moodtalk.app${JS}" | grep -q "eft-guide" && {
+            echo "❌ Found 'eft-guide' in live bundle"; exit 1;
+          } || echo "✅ No 'eft-guide' in live bundle"
 
       - name: Health check (homepage)
         run: |

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
         display: 'standalone',
         scope: '/',
         start_url: '/',
-        version: '2.2.0',
+        version: new Date().toISOString(), // 빌드마다 바뀌도록
         icons: [
           {
             src: 'vite.svg',
@@ -44,7 +44,9 @@ export default defineConfig({
         ]
       },
       workbox: {
-        cacheId: 'eft-ai-v2.2.0',
+        clientsClaim: true,
+        skipWaiting: true,
+        cacheId: `eft-ai-${new Date().getTime()}`, // 빌드마다 고유 캐시 ID
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
         runtimeCaching: [
           {


### PR DESCRIPTION
- PWA: Force cache invalidation with dynamic version/cacheId
- Deploy: Enhance rsync with --delete and comprehensive sync flags
- Test: Add automated bundle verification to prevent eft-guide regression
- Cache: Enable clientsClaim and skipWaiting for immediate updates

This should eliminate the eft-guide vs ar-holistic route redirect issue.
