### PR TITLE
force: trigger deployment to clear eft-guide cache

### DIFF
--- a/FORCE_DEPLOY.md
+++ b/FORCE_DEPLOY.md
@@ -1,0 +1,4 @@
+# Force deployment to clear eft-guide cache
+
+Build timestamp: 2025년 09월 28일 일 오후  4:35:41
+Bundle should be completely clean of eft-guide references.


### PR DESCRIPTION
🔄 Force clear deployment cache
- Clean build confirmed: eft-guide count = 0
- Trigger fresh deployment to moodtalk.app
- Remove stale bundle references

Previous bundle had 3 eft-guide references (cache issue) New bundle should be completely clean

🚀 Generated with [Claude Code](https://claude.ai/code)