### PR TITLE
Fix: Add redirect route from /eft-guide to /ar-holistic

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,6 +74,8 @@ const App: React.FC = () => {
             path="/ar/calibration"
             element={<ArCalibrationPage />}
           />
+          {/* EFT Guide 리다이렉트 - /eft-guide를 /ar-holistic으로 리다이렉트 */}
+          <Route path="/eft-guide" element={<Navigate to="/ar-holistic" replace />} />
           {/* 잘못된 경로는 홈으로 리다이렉트 */}
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>


### PR DESCRIPTION
- 3D가이드 버튼 클릭 시 잘못된 URL(/eft-guide) 문제 해결
- /eft-guide 경로를 /ar-holistic으로 자동 리다이렉트 추가
- React Router의 catch-all route에서 발생한 홈페이지 리다이렉트 문제 해결

