### PR TITLE
Add: 방어적 리다이렉트 라우트 추가 (/eft-guide → /ar-holistic)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -74,6 +74,8 @@ const App: React.FC = () => {
             path="/ar/calibration"
             element={<ArCalibrationPage />}
           />
+          {/* 방어적 리다이렉트: /eft-guide → /ar-holistic */}
+          <Route path="/eft-guide" element={<Navigate to="/ar-holistic" replace />} />
           {/* 잘못된 경로는 홈으로 리다이렉트 */}
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>


### PR DESCRIPTION
- React Router에 방어적 리다이렉트 추가
- /eft-guide 접근 시 /ar-holistic으로 즉시 리다이렉트
- 배포된 버전과 GitHub 코드 차이로 인한 문제 방지
- catch-all route 이전에 배치하여 우선순위 보장

