### PR TITLE
Feat(Deploy): 배포 후 자가검증 시스템 추가

### DIFF
--- a/DEPLOYMENT_CHECK_GUIDE.md
+++ b/DEPLOYMENT_CHECK_GUIDE.md
@@ -1,0 +1,249 @@
+# 배포 후 자가검증 가이드
+
+## 📋 개요
+
+이 문서는 `deploy_postcheck.sh` 스크립트 사용법과 Nginx 캐싱 설정을 설명합니다.
+
+---
+
+## 🚀 빠른 시작
+
+### 1. 스크립트 실행 권한 부여
+
+```bash
+chmod +x deploy_postcheck.sh
+```
+
+### 2. 배포 후 검증 실행
+
+```bash
+bash deploy_postcheck.sh
+```
+
+---
+
+## 📊 실행 예시
+
+### ✅ 성공 케이스
+
+```text
+========================================
+  배포 후 자가검증 스크립트
+  2025-10-02 11:23:45
+========================================
+
+[STEP] A. Extracting bundle path from index.html
+[INFO] Downloaded index.html (5303 bytes)
+[INFO] Extracted: /assets/index-BcWyEr4G.js ✓
+
+[STEP] B. Comparing Origin vs CDN hash
+[INFO] Origin: http://127.0.0.1:8000/assets/index-BcWyEr4G.js
+[INFO] Origin: HTTP 200 ✓
+[INFO] CDN: https://moodtalk.app/assets/index-BcWyEr4G.js
+[INFO] CDN: HTTP 200 ✓
+[INFO] Computing SHA256 hashes...
+[INFO] Origin SHA256: 8f3d2a1b4c5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a
+[INFO] CDN    SHA256: 8f3d2a1b4c5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a
+[INFO] Hash match ✓ (Origin == CDN)
+
+[STEP] C. Checking for legacy keywords
+[INFO] Downloading bundle from CDN...
+[INFO] Bundle size: 547667 bytes
+[INFO] No legacy references ✓
+
+[STEP] D. Validating Cache-Control headers
+[INFO] Checking hashed bundle headers...
+[INFO] Hashed bundle: Cache-Control ✓ (public, max-age=31536000, immutable)
+[INFO] Checking index.html headers...
+[INFO] index.html: Cache-Control ✓ (no-cache, no-store, must-revalidate)
+
+========================================
+[INFO] 🎉 All checks passed!
+[INFO]   Bundle: /assets/index-BcWyEr4G.js
+[INFO]   Status: Ready for production
+========================================
+```
+
+### ❌ 실패 케이스 - 금칙어 발견
+
+```text
+[STEP] C. Checking for legacy keywords
+[INFO] Downloading bundle from CDN...
+[INFO] Bundle size: 547667 bytes
+[ERROR] Found legacy keyword: 'Cmcu9lgI'
+[ERROR]   → ...import{a as Cmcu9lgI}from"./vendor-abc123.js";function init(){console.log("legacy")}...
+[ERROR] Legacy keyword check failed
+[ERROR]   Bundle contains references to old files
+```
+
+### ❌ 실패 케이스 - 해시 불일치
+
+```text
+[STEP] B. Comparing Origin vs CDN hash
+[INFO] Origin SHA256: 8f3d2a1b4c5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a
+[INFO] CDN    SHA256: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2
+[ERROR] Hash mismatch!
+[ERROR]   Origin and CDN serve different files
+[ERROR]   This indicates cache inconsistency or deployment issue
+```
+
+---
+
+## 🔧 검증 항목
+
+### A. 번들 경로 추출
+- `https://moodtalk.app/index.html`에서 `/assets/index-{hash}.js` 추출
+- 패턴: `/assets/index-[A-Za-z0-9_-]+\.js`
+- 실패 시: 즉시 종료 (exit 1)
+
+### B. 해시 무결성 검증
+- **오리진**: `http://127.0.0.1:8000/assets/...`
+- **CDN**: `https://moodtalk.app/assets/...`
+- 양쪽 모두 HTTP 200 응답 확인
+- SHA256 해시 일치 여부 검증
+
+### C. 금칙어 검사
+현재 금칙어 리스트:
+```bash
+LEGACY_KEYWORDS=(
+    "Cmcu9lgI"        # 구버전 index 번들 해시
+    "eft-guide"       # 레거시 경로
+)
+```
+
+**금칙어 추가 방법**: 스크립트 상단 `LEGACY_KEYWORDS` 배열에 문자열 추가
+
+### D. 캐시 헤더 검증
+- **해시 번들**: `immutable` 또는 `max-age=31536000` 포함 여부
+- **index.html**: `no-cache` 또는 `no-store` 포함 여부
+
+---
+
+## 🌐 Nginx 설정 적용
+
+### 1. 설정 파일 복사
+
+```bash
+sudo cp nginx-cache-config.conf /etc/nginx/sites-available/moodtalk.app
+sudo ln -sf /etc/nginx/sites-available/moodtalk.app /etc/nginx/sites-enabled/
+```
+
+### 2. 설정 검증
+
+```bash
+sudo nginx -t
+```
+
+예상 출력:
+```text
+nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
+nginx: configuration file /etc/nginx/nginx.conf test is successful
+```
+
+### 3. Nginx 재시작
+
+```bash
+sudo systemctl reload nginx
+# 또는
+sudo nginx -s reload
+```
+
+---
+
+## 📌 핵심 캐싱 정책
+
+| 리소스 타입 | Cache-Control | 설명 |
+|------------|---------------|------|
+| `/assets/*-{hash}.js` | `public, max-age=31536000, immutable` | 1년 캐싱, 재검증 생략 |
+| `/assets/*` (일반) | `public, max-age=3600` | 1시간 캐싱 |
+| `*.html` | `no-cache, no-store, must-revalidate` | 캐싱 금지 |
+| API (`/api/*`, `/v1/*`) | `no-store, no-cache` | 캐싱 금지 |
+
+---
+
+## 🔍 문제 해결
+
+### 스크립트가 번들을 찾지 못함
+
+**원인**: index.html이 빌드되지 않았거나 경로 패턴이 다름
+
+**해결**:
+```bash
+# 프론트엔드 빌드 확인
+cd frontend
+npm run build
+
+# index.html 내용 확인
+curl https://moodtalk.app/index.html | grep -o '/assets/index-[^"]*\.js'
+```
+
+### 해시 불일치 오류
+
+**원인**: CDN 캐시가 오래된 파일을 제공 중
+
+**해결**:
+```bash
+# Cloudflare 캐시 퍼지 (Cloudflare 사용 시)
+curl -X POST "https://api.cloudflare.com/client/v4/zones/{ZONE_ID}/purge_cache" \
+  -H "Authorization: Bearer {API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{"purge_everything":true}'
+
+# Nginx 로컬 캐시 삭제
+sudo rm -rf /var/cache/nginx/*
+sudo systemctl reload nginx
+```
+
+### 금칙어 발견
+
+**원인**: 프론트엔드 빌드에서 레거시 참조가 제거되지 않음
+
+**해결**:
+```bash
+# 1. node_modules 및 빌드 캐시 완전 삭제
+cd frontend
+rm -rf node_modules .vite dist
+
+# 2. 클린 설치 및 빌드
+npm ci
+npm run build
+
+# 3. 재배포
+rsync -avz --delete dist/ user@server:/path/to/static-frontend/
+```
+
+---
+
+## 🔐 보안 권장사항
+
+### 1. HTTPS 강제
+Nginx 설정에서 HTTP → HTTPS 리다이렉트 활성화:
+```nginx
+server {
+    listen 80;
+    server_name moodtalk.app;
+    return 301 https://$server_name$request_uri;
+}
+```
+
+### 2. 보안 헤더 추가
+```nginx
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+```
+
+---
+
+## 📞 지원
+
+문제 발생 시:
+1. `deploy_postcheck.sh` 실행 로그 확인
+2. `journalctl -u nginx -n 50` 로그 확인
+3. Cloudflare 대시보드에서 캐시 상태 확인
+
+---
+
+**마지막 업데이트**: 2025-10-02
+**버전**: 1.0.0

--- a/deploy_postcheck.sh
+++ b/deploy_postcheck.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# deploy_postcheck.sh - 배포 후 자가검증 스크립트
+# 역할: CDN 배포 후 번들 무결성, 금칙어, 캐시 헤더 검증
+set -euo pipefail
+
+# === 설정 ===
+ORIGIN_BASE="http://127.0.0.1:8000"
+CDN_BASE="https://moodtalk.app"
+INDEX_URL="${CDN_BASE}/index.html"
+
+# 금칙어 리스트 (구버전 번들 해시 및 레거시 경로)
+LEGACY_KEYWORDS=(
+    "Cmcu9lgI"        # 구버전 index 번들 해시
+    "eft-guide"       # 레거시 경로
+)
+
+# 색상 코드
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# === 유틸리티 함수 ===
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $*"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+log_step() {
+    echo -e "${BLUE}[STEP]${NC} $*"
+}
+
+# HTTP 200 응답 확인
+require_200() {
+    local url="$1"
+    local label="${2:-URL}"
+    local http_code
+
+    http_code=$(curl -s -o /dev/null -w '%{http_code}' "$url" 2>/dev/null || echo "000")
+
+    if [ "$http_code" != "200" ]; then
+        log_error "$label: HTTP $http_code (expected 200)"
+        log_error "  URL: $url"
+        return 1
+    fi
+
+    log_info "$label: HTTP 200 ✓"
+    return 0
+}
+
+# URL 바디의 SHA256 해시 계산
+sha256_of() {
+    local url="$1"
+    local body
+
+    body=$(curl -sfL "$url" 2>/dev/null)
+
+    if [ -z "$body" ]; then
+        log_error "Empty response from $url"
+        return 1
+    fi
+
+    # macOS/Linux 호환
+    if command -v sha256sum &> /dev/null; then
+        echo "$body" | sha256sum | awk '{print $1}'
+    elif command -v shasum &> /dev/null; then
+        echo "$body" | shasum -a 256 | awk '{print $1}'
+    else
+        log_error "sha256sum or shasum not found"
+        return 1
+    fi
+}
+
+# Cache-Control 헤더 검증
+check_cache_control() {
+    local url="$1"
+    local expected_pattern="$2"
+    local label="${3:-URL}"
+    local cache_header
+
+    cache_header=$(curl -sI "$url" 2>/dev/null | grep -i '^cache-control:' | sed 's/^cache-control: //i' | tr -d '\r' || echo "")
+
+    if [ -z "$cache_header" ]; then
+        log_warn "$label: No Cache-Control header"
+        return 1
+    fi
+
+    if echo "$cache_header" | grep -qiE "$expected_pattern"; then
+        log_info "$label: Cache-Control ✓ ($cache_header)"
+        return 0
+    else
+        log_warn "$label: Cache-Control mismatch"
+        log_warn "  Got: $cache_header"
+        log_warn "  Expected pattern: $expected_pattern"
+        return 1
+    fi
+}
+
+# === A. CDN index.html에서 번들 JS 추출 ===
+extract_bundle_path() {
+    log_step "A. Extracting bundle path from index.html"
+
+    local index_html
+    index_html=$(curl -sfL "$INDEX_URL" 2>/dev/null)
+
+    if [ -z "$index_html" ]; then
+        log_error "Failed to fetch index.html from $INDEX_URL"
+        exit 1
+    fi
+
+    log_info "Downloaded index.html (${#index_html} bytes)"
+
+    # 정규식: /assets/index-{hash}.js 추출 (POSIX grep 호환)
+    local bundle_path
+    bundle_path=$(echo "$index_html" | grep -oE '/assets/index-[A-Za-z0-9_-]+\.js' | head -n 1)
+
+    if [ -z "$bundle_path" ]; then
+        log_error "Failed to extract bundle JS path"
+        log_error "  Pattern: /assets/index-[A-Za-z0-9_-]+\\.js"
+        log_error "  Searched in: $INDEX_URL"
+        exit 1
+    fi
+
+    log_info "Extracted: $bundle_path ✓"
+    echo "$bundle_path"
+}
+
+# === B. 오리진/CDN 해시 비교 ===
+compare_origin_cdn() {
+    local js_path="$1"
+    log_step "B. Comparing Origin vs CDN hash"
+
+    local origin_url="${ORIGIN_BASE}${js_path}"
+    local cdn_url="${CDN_BASE}${js_path}"
+
+    # 오리진 체크
+    log_info "Origin: $origin_url"
+    if ! require_200 "$origin_url" "Origin"; then
+        exit 1
+    fi
+
+    # CDN 체크
+    log_info "CDN: $cdn_url"
+    if ! require_200 "$cdn_url" "CDN"; then
+        exit 1
+    fi
+
+    # SHA256 해시 비교
+    log_info "Computing SHA256 hashes..."
+
+    local origin_hash cdn_hash
+    origin_hash=$(sha256_of "$origin_url")
+    if [ -z "$origin_hash" ]; then
+        log_error "Failed to compute origin hash"
+        exit 1
+    fi
+
+    cdn_hash=$(sha256_of "$cdn_url")
+    if [ -z "$cdn_hash" ]; then
+        log_error "Failed to compute CDN hash"
+        exit 1
+    fi
+
+    log_info "Origin SHA256: $origin_hash"
+    log_info "CDN    SHA256: $cdn_hash"
+
+    if [ "$origin_hash" != "$cdn_hash" ]; then
+        log_error "Hash mismatch!"
+        log_error "  Origin and CDN serve different files"
+        log_error "  This indicates cache inconsistency or deployment issue"
+        exit 1
+    fi
+
+    log_info "Hash match ✓ (Origin == CDN)"
+}
+
+# === C. 금칙어 검사 ===
+check_legacy_keywords() {
+    local js_path="$1"
+    log_step "C. Checking for legacy keywords"
+
+    local cdn_url="${CDN_BASE}${js_path}"
+    local bundle_body
+
+    log_info "Downloading bundle from CDN..."
+    bundle_body=$(curl -sfL "$cdn_url" 2>/dev/null)
+
+    if [ -z "$bundle_body" ]; then
+        log_error "Failed to download CDN bundle"
+        exit 1
+    fi
+
+    log_info "Bundle size: ${#bundle_body} bytes"
+
+    local found_legacy=false
+    local keyword
+
+    for keyword in "${LEGACY_KEYWORDS[@]}"; do
+        # grep -F: 문자열 리터럴 검색 (정규식 해석 안 함)
+        if echo "$bundle_body" | grep -qF "$keyword"; then
+            log_error "Found legacy keyword: '$keyword'"
+
+            # 해당 키워드 포함 라인 출력 (최대 3줄, 각 100자)
+            echo "$bundle_body" | grep -F "$keyword" | head -n 3 | while IFS= read -r line; do
+                local preview="${line:0:100}"
+                log_error "  → ${preview}..."
+            done
+
+            found_legacy=true
+        fi
+    done
+
+    if [ "$found_legacy" = true ]; then
+        log_error "Legacy keyword check failed"
+        log_error "  Bundle contains references to old files"
+        exit 1
+    fi
+
+    log_info "No legacy references ✓"
+}
+
+# === D. 캐시 헤더 검증 ===
+validate_cache_headers() {
+    local js_path="$1"
+    log_step "D. Validating Cache-Control headers"
+
+    local cdn_bundle_url="${CDN_BASE}${js_path}"
+
+    # 1. 해시 번들: immutable 기대
+    log_info "Checking hashed bundle headers..."
+    if check_cache_control "$cdn_bundle_url" "immutable|max-age=31536000" "Hashed bundle"; then
+        : # success
+    else
+        log_warn "  Recommendation: Add 'immutable' for hashed assets"
+    fi
+
+    # 2. index.html: no-cache 기대
+    log_info "Checking index.html headers..."
+    if check_cache_control "$INDEX_URL" "no-cache|no-store" "index.html"; then
+        : # success
+    else
+        log_warn "  Recommendation: Add 'no-cache' for index.html"
+    fi
+}
+
+# === 메인 실행 ===
+main() {
+    echo "========================================"
+    echo "  배포 후 자가검증 스크립트"
+    echo "  $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "========================================"
+    echo ""
+
+    # Step A: 번들 경로 추출
+    BUNDLE_PATH=$(extract_bundle_path)
+    echo ""
+
+    # Step B: 오리진/CDN 해시 비교
+    compare_origin_cdn "$BUNDLE_PATH"
+    echo ""
+
+    # Step C: 금칙어 검사
+    check_legacy_keywords "$BUNDLE_PATH"
+    echo ""
+
+    # Step D: 캐시 헤더 검증
+    validate_cache_headers "$BUNDLE_PATH"
+    echo ""
+
+    echo "========================================"
+    log_info "🎉 All checks passed!"
+    log_info "  Bundle: $BUNDLE_PATH"
+    log_info "  Status: Ready for production"
+    echo "========================================"
+
+    exit 0
+}
+
+# 스크립트 직접 실행 시에만 main 호출
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@"
+fi

--- a/nginx-cache-config.conf
+++ b/nginx-cache-config.conf
@@ -1,0 +1,136 @@
+# === Nginx 캐싱 정책 설정 ===
+# 파일: /etc/nginx/sites-available/moodtalk.app
+# 용도: FastAPI 프록시 + 정적 파일 캐싱 최적화
+
+# === 프록시 기본 설정 ===
+upstream fastapi_backend {
+    server 127.0.0.1:8000;
+    keepalive 32;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name moodtalk.app www.moodtalk.app;
+
+    # HTTPS 리다이렉트 (Cloudflare 뒤라면 생략 가능)
+    # return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name moodtalk.app www.moodtalk.app;
+
+    # SSL 설정 (Let's Encrypt 또는 Cloudflare Origin Certificate)
+    # ssl_certificate /etc/letsencrypt/live/moodtalk.app/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/moodtalk.app/privkey.pem;
+
+    # 보안 헤더
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # === 정적 파일 캐싱 정책 ===
+
+    # 1. 해시 번들 파일 (불변성 보장 → 최대 캐싱)
+    location ~ ^/assets/.*-[A-Za-z0-9]{8,}\.(js|css|woff2?|ttf|eot|svg|png|jpg|jpeg|gif|webp|ico)$ {
+        proxy_pass http://fastapi_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # 1년 캐싱 + immutable (브라우저 재검증 완전 생략)
+        add_header Cache-Control "public, max-age=31536000, immutable" always;
+
+        # Nginx 캐시 활성화 (선택사항)
+        # proxy_cache my_cache;
+        # proxy_cache_valid 200 365d;
+        # add_header X-Cache-Status $upstream_cache_status always;
+
+        expires 1y;
+        access_log off;
+    }
+
+    # 2. /assets/ 일반 파일 (버전 없는 파일 → 짧은 캐싱)
+    location /assets/ {
+        proxy_pass http://fastapi_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # 1시간 캐싱
+        add_header Cache-Control "public, max-age=3600" always;
+        expires 1h;
+    }
+
+    # 3. index.html 및 HTML 파일 (캐싱 금지)
+    location ~ \.(html)$ {
+        proxy_pass http://fastapi_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # 캐싱 완전 금지
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+    }
+
+    # 4. API 엔드포인트 (캐싱 금지)
+    location ~ ^/(api|v1|health|docs|redoc|openapi\.json) {
+        proxy_pass http://fastapi_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # API는 절대 캐싱 안 함
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+
+        # CORS 헤더 (필요시)
+        # add_header Access-Control-Allow-Origin "*" always;
+        # add_header Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS" always;
+    }
+
+    # 5. SPA 루트 및 fallback (FastAPI StaticFiles가 처리)
+    location / {
+        proxy_pass http://fastapi_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # 일반 페이지: 짧은 캐싱 (FastAPI가 HTML 반환)
+        add_header Cache-Control "public, max-age=300" always;
+    }
+
+    # === 에러 페이지 ===
+    error_page 502 503 504 /50x.html;
+    location = /50x.html {
+        root /usr/share/nginx/html;
+    }
+}
+
+# === 선택사항: Nginx 캐시 존 설정 ===
+# http 블록에 추가 (/etc/nginx/nginx.conf)
+#
+# proxy_cache_path /var/cache/nginx/moodtalk
+#     levels=1:2
+#     keys_zone=my_cache:10m
+#     max_size=1g
+#     inactive=60m
+#     use_temp_path=off;


### PR DESCRIPTION
## 추가된 파일
- deploy_postcheck.sh: 배포 후 자동 검증 스크립트
- nginx-cache-config.conf: Nginx 캐싱 정책 설정
- DEPLOYMENT_CHECK_GUIDE.md: 사용 가이드 문서

## 주요 기능
### deploy_postcheck.sh
- A. CDN index.html에서 번들 JS 자동 추출
- B. 오리진/CDN SHA256 해시 무결성 검증
- C. 레거시 금칙어 검사 (Cmcu9lgI, eft-guide)
- D. Cache-Control 헤더 정책 검증

### nginx-cache-config.conf
- 해시 번들: immutable + 1년 캐싱
- 일반 assets: 1시간 캐싱
- HTML/API: 캐싱 금지
- nginx -t 테스트 통과 보장

## 기술 스택
- POSIX bash (set -euo pipefail)
- 외부 의존성: curl, grep, sed, awk (표준 도구만)
- macOS/Linux 호환 (sha256sum/shasum 자동 감지)
