### PR TITLE
Add cushion follow-up flow and manual EFT launcher

### DIFF
--- a/frontend/src/components/feature/AIChat.tsx
+++ b/frontend/src/components/feature/AIChat.tsx
@@ -19,7 +19,7 @@ import type {
 } from '../../types/actionTypes';
 import { recToARParams } from '../../lib/eftAdapter';
 import { EftRecButton } from '../eft';
-import {
+import { 
   createSession,
   onUserMessage,
   enforceTwoTurnRule,
@@ -29,7 +29,8 @@ import {
   enforceLength,
   extractSlotsFrom,
   ensureTwoParagraphs,
-  type ConversationSession
+  type ConversationSession,
+  type ConversationState
 } from '../../types/conversationState';
 import {
   fsCreateTurn,
@@ -49,7 +50,15 @@ interface Message {
     processing_time?: number;
     emergency_detected?: boolean;
     professional_referral?: boolean;
+    conversationState?: ConversationState;
+    turnCount?: number;
+    actionResults?: ActionObject[];
   };
+}
+
+interface CushionFollowupState {
+  remainder: string;
+  metadata?: Message['metadata'];
 }
 
 interface AIChatProps {
@@ -62,6 +71,13 @@ type AITier = 'free' | 'premium' | 'enterprise';
 
 // turnId 유틸 - zero-pad로 정렬 안정성 확보
 const turnIdOf = (n: number) => String(n).padStart(4, '0');
+
+const LONG_RESPONSE_THRESHOLD = 460;
+const POSITIVE_FOLLOWUP_REGEX = /(네|넵|좋아요|좋습니다|괜찮아요|계속|더|알려줘|부탁해|응|그래요?)/i;
+const NEGATIVE_FOLLOWUP_REGEX = /(아니|않아|안돼|그만|싫|나중|필요없|보류|괜찮(?:으니|습니다만|지만))/i;
+const CUSHION_LEAD = '먼저 말씀드리고 싶은 것은';
+const CUSHION_ASK = '혹시 괜찮으시다면 이어서 조금 더 자세히 안내해드릴까요?';
+const CUSHION_CONTINUE = '그럼 이어서 부드럽게 안내드릴게요.';
 
 // 🔍 안전 파서: 여러 응답 스키마에서 텍스트를 추출
 const extractText = (res: any): string => {
@@ -262,6 +278,8 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
   const [pendingEftRecommendation, setPendingEftRecommendation] = useState<EftRecommendationPayload | null>(null);
   const [pendingMoodCheck, setPendingMoodCheck] = useState<MoodCheckPayload | null>(null);
   const [pendingResource, setPendingResource] = useState<ResourceOfferPayload | null>(null);
+  const [pendingCushionFollowup, setPendingCushionFollowup] = useState<CushionFollowupState | null>(null);
+  const [manualEftRequested, setManualEftRequested] = useState(false);
 
   // 🔥 EFT 세션 훅 통합
   const eftSessionHook = useEFTSessionHook({
@@ -285,6 +303,11 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
   // 뒤로가기 핸들러
   const handleGoBack = () => {
     navigate('/');
+  };
+
+  const handleManualEFTStart = () => {
+    setManualEftRequested(true);
+    setShowPreSUDS(true);
   };
 
   // 🔍 그림자 테스트: fire-and-forget 비교 (UI 영향 없음)
@@ -488,40 +511,73 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
   ];
 
   // Qwen 호출 파이프라인 (상태머신 순서 준수)
-  const onSend = async (userText: string) => {
-    if (!userText.trim() || loading) return;
+  const onSend = async (rawInput: string) => {
+    const trimmed = rawInput.trim();
+    if (!trimmed || loading) return;
+
+    // 1) 사용자 입력 도착 - 핵심명사 추출 및 상태 전이
+    onUserMessage(session, trimmed);
+
+    const userMessage: Message = {
+      role: 'user',
+      content: trimmed,
+      timestamp: Date.now()
+    };
+    setMessages(prev => [...prev, userMessage]);
+    setInputMessage('');
+
+    const followup = pendingCushionFollowup;
+    const wantsMore = followup ? POSITIVE_FOLLOWUP_REGEX.test(trimmed) : false;
+    const declinesMore = followup ? NEGATIVE_FOLLOWUP_REGEX.test(trimmed) : false;
+
+    if (followup && (wantsMore || declinesMore)) {
+      setPendingCushionFollowup(null);
+
+      const followupMessage: Message = wantsMore
+        ? {
+            role: 'ai',
+            content: `${CUSHION_CONTINUE} ${followup.remainder}`.trim(),
+            timestamp: Date.now(),
+            metadata: {
+              ...followup.metadata,
+              confidence: followup.metadata?.confidence ?? 0.85,
+            },
+          }
+        : {
+            role: 'ai',
+            content: '알겠습니다. 필요하실 때 언제든지 더 이어서 말씀드릴게요.',
+            timestamp: Date.now(),
+            metadata: {
+              ...followup.metadata,
+              confidence: followup.metadata?.confidence ?? 0.8,
+            },
+          };
+
+      setMessages(prev => [...prev, followupMessage]);
+      return;
+    }
+
+    setPendingCushionFollowup(null);
     setLoading(true);
 
     try {
-      // 1) 사용자 입력 도착 - 핵심명사 추출 및 상태 전이
-      onUserMessage(session, userText);
-
-      // UI 메시지 추가
-      const userMessage: Message = {
-        role: 'user',
-        content: userText.trim(),
-        timestamp: Date.now()
-      };
-      setMessages(prev => [...prev, userMessage]);
-      setInputMessage('');
-
       // 2) 엔진 응답 생성 후(확정 직전) 상태 정책 적용
       enforceTwoTurnRule(session);
 
       // 슬롯 추출 (보조)
-      const slots = extractSlotsFrom(userText);
+      const slots = extractSlotsFrom(trimmed);
 
       // 시스템 프롬프트 구성 (+ 슬롯 JSON)
       const systemWithSlots = SYSTEM_PROMPT + `\n[슬롯]\n${JSON.stringify(slots)}`;
 
       // Qwen 호출 (기존 서버 래퍼 사용)
-      console.log(`🚀 Qwen 호출 시작 (${selectedTier} 티어, 상태: ${session.state}, 턴: ${session.turn}):`, userText);
+      console.log(`🚀 Qwen 호출 시작 (${selectedTier} 티어, 상태: ${session.state}, 턴: ${session.turn}):`, trimmed);
 
       let serverResponse: ChatResponse;
 
       if (selectedTier === 'free') {
         // 무료: 기존 Engine A/B 사용
-        serverResponse = await serverAI.chat(userText, {
+        serverResponse = await serverAI.chat(trimmed, {
           userId: userId,
           maxTokens: 300,
           temperature: 0.4
@@ -531,7 +587,7 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
         if (PREMIUM_VIA_BACKEND) {
           // 경로 1: 백엔드 경유 (/api/chat/premium)
           const payload = {
-            message: userText,
+            message: trimmed,
             temperature: 0.7,
             max_tokens: 700,
             ...(session?.sessionId ? { sessionId: session.sessionId } : {}),
@@ -569,9 +625,9 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
               max_tokens: 700,
               messages: [
                 { role: 'system', content: systemWithSlots },
-                { role: 'user', content: userText }
-              ]
-            })
+              { role: 'user', content: trimmed }
+          ]
+        })
           });
 
           if (!response.ok) {
@@ -593,7 +649,7 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
         }
 
         // 🔍 그림자 테스트 (비동기, UI 영향 없음)
-        shadowFireAndForget(userText, serverResponse);
+        shadowFireAndForget(trimmed, serverResponse);
       }
       
       // 🔥 3) 백엔드가 이미 토큰 제거 & 액션 포함해 줌
@@ -618,7 +674,7 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
       reply = sanitizeAssistantText(session, reply);
 
       // 3-2. 안전성 검사 (위험 키워드 감지 + 안전 안내)
-      reply = applySafetyCheck(session, userText, reply);
+      reply = applySafetyCheck(session, trimmed, reply);
 
       // 3-3. 반복 방지 적용 (24시간 캐시)
       reply = dampenRepetition(session, reply);
@@ -628,26 +684,48 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
 
       // UI 반영 (2단락 보장)
       const paragraphs = ensureTwoParagraphs(reply);
-      const finalContent = paragraphs.join('\n\n');
+      let finalContent = paragraphs.join('\n\n');
+      let followupState: CushionFollowupState | null = null;
+
+      const baseMetadata: Message['metadata'] = {
+        emotion_analysis: serverResponse.emotion_analysis,
+        eft_recommendations: serverResponse.eft_recommendations,
+        confidence: serverResponse.confidence_score,
+        processing_time: serverResponse.processing_time,
+        emergency_detected: serverResponse.emergency_detected,
+        professional_referral: serverResponse.professional_referral,
+        conversationState: session.state,
+        turnCount: session.turn,
+        actionResults,
+      };
+
+      if (finalContent.length >= LONG_RESPONSE_THRESHOLD && paragraphs.length >= 2) {
+        const [firstParagraph, ...restParagraphs] = paragraphs;
+        const restContent = restParagraphs.join('\n\n').trim();
+        const leadParagraph = firstParagraph.trim().startsWith(CUSHION_LEAD)
+          ? firstParagraph.trim()
+          : `${CUSHION_LEAD}, ${firstParagraph.trim()}`;
+
+        if (restContent) {
+          finalContent = `${leadParagraph}\n\n${CUSHION_ASK}`;
+          followupState = {
+            remainder: restContent,
+            metadata: baseMetadata,
+          };
+        } else {
+          finalContent = leadParagraph;
+        }
+      }
 
       const aiMessage: Message = {
         role: 'ai',
         content: finalContent,
         timestamp: Date.now(),
-        metadata: {
-          emotion_analysis: serverResponse.emotion_analysis,
-          eft_recommendations: serverResponse.eft_recommendations,
-          confidence: serverResponse.confidence_score,
-          processing_time: serverResponse.processing_time,
-          emergency_detected: serverResponse.emergency_detected,
-          professional_referral: serverResponse.professional_referral,
-          conversationState: session.state,
-          turnCount: session.turn,
-          actionResults // 🔥 AI 액션 토큰 처리 결과 포함
-        }
+        metadata: baseMetadata,
       };
 
       setMessages(prev => [...prev, aiMessage]);
+      setPendingCushionFollowup(followupState);
 
       // 4) 메시지 렌더링 & turn 카운트 증가 (응답 확정 후)
       session.turn += 1;
@@ -1165,6 +1243,21 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
         </div>
       </div>
 
+      <button
+        type="button"
+        onClick={handleManualEFTStart}
+        disabled={manualEftRequested || showPreSUDS || showPostSUDS}
+        className={`fixed bottom-28 right-4 z-40 flex items-center gap-2 rounded-full px-4 py-3 text-sm font-semibold shadow-lg focus:outline-none focus:ring-2 focus:ring-emerald-300 transition-colors ${
+          manualEftRequested || showPreSUDS || showPostSUDS
+            ? 'bg-emerald-300 text-white cursor-not-allowed'
+            : 'bg-emerald-500 text-white hover:bg-emerald-600'
+        }`}
+        aria-label="지금 EFT 진행해보기"
+      >
+        <span>지금 EFT 진행해보기</span>
+        <span aria-hidden="true">🪄</span>
+      </button>
+
       {/* SUDS 모달들 */}
       <SUDSModal
         open={showPreSUDS}
@@ -1185,10 +1278,31 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
 
             console.log('사전 SUDS 저장 완료:', { sessionId, turnId, sudsPre: rating });
 
-            // EFT 개입 시작 메시지 자동 전송
-            setTimeout(() => {
-              onSend('이제 함께 EFT 세션을 진행해보겠습니다. 준비되셨나요?');
-            }, 1000);
+            if (manualEftRequested) {
+              setManualEftRequested(false);
+
+              const acknowledgement: Message = {
+                role: 'ai',
+                content: '살짝 숨을 고르셨다면, 이제 AR 가이드로 편안하게 이어가실 수 있도록 도와드릴게요.',
+                timestamp: Date.now(),
+                metadata: {
+                  confidence: 0.9,
+                  conversationState: session.state,
+                  turnCount: session.turn,
+                },
+              };
+
+              setMessages(prev => [...prev, acknowledgement]);
+
+              setTimeout(() => {
+                navigate(`/ar-holistic?intensity=${rating}`);
+              }, 500);
+            } else {
+              // EFT 개입 시작 메시지 자동 전송
+              setTimeout(() => {
+                onSend('이제 함께 EFT 세션을 진행해보겠습니다. 준비되셨나요?');
+              }, 1000);
+            }
           } catch (error) {
             console.error('사전 SUDS 저장 실패:', error);
             // 비블로킹 피드백 + 모달 즉시 복구로 매끄러운 사용 흐름
@@ -1196,7 +1310,10 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
             setShowPreSUDS(true);
           }
         }}
-        onClose={() => setShowPreSUDS(false)}
+        onClose={() => {
+          setShowPreSUDS(false);
+          setManualEftRequested(false);
+        }}
         currentValue={suds.pre}
       />
 

--- a/frontend/src/components/modals/SUDSModal.tsx
+++ b/frontend/src/components/modals/SUDSModal.tsx
@@ -49,7 +49,7 @@ const SUDSModal: React.FC<SUDSModalProps> = ({
   const isPre = label === 'pre';
   const title = isPre ? 'EFT 시작 전 상태' : 'EFT 적용 후 상태';
   const description = isPre
-    ? '현재 느끼는 스트레스/불편함 정도를 선택해주세요 (0=매우 편안, 10=매우 불편).'
+    ? 'EFT AR 가이드를 시작하기 전에 지금 느끼는 스트레스/불편함 정도를 선택해주세요 (0=매우 편안, 10=매우 불편).'
     : 'EFT 적용 후 스트레스/불편함의 변화를 평가해주세요.';
 
   const getScoreDescription = (v: number): string => {
@@ -165,7 +165,7 @@ const SUDSModal: React.FC<SUDSModalProps> = ({
             </Button>
           )}
           <Button onClick={() => onSubmit(score)} className="flex-1 bg-blue-600 text-white hover:bg-blue-700">
-            {isPre ? '시작하기' : '완료하기'}
+            {isPre ? 'EFT 시작하기' : '완료하기'}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add cushion follow-up handling with continuation prompts in the AI chat pipeline
- introduce a fixed "지금 EFT 진행해보기" entry point that runs a pre-SUDS check before launching the AR EFT guide
- refresh the SUDS modal messaging so the start button explicitly reads "EFT 시작하기"

## Testing
- npm run build *(fails: missing vite/vitest type definitions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5cd7717ac832aa9f5bff4dd32ce0e