### PR TITLE
Fix: AIChat 빌드 오류 수정 (중복 fetch 선언 제거)

### DIFF
--- a/frontend/src/components/feature/AIChat.tsx
+++ b/frontend/src/components/feature/AIChat.tsx
@@ -877,7 +877,6 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
     try {
       if (canPersistToBackend) {
         // 백엔드 SUDS 기록 API 호출 (세션이 초기화된 경우에만)
-        const response = await fetch(joinUrl(API_BASE_URL, `/memory/${sessionId}/suds`), {
         const response = await fetch(`${API_BASE_URL}/api/memory/${sessionId}/suds`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -928,7 +927,6 @@ const AIChat: React.FC<AIChatProps> = ({ userId }) => {
       // 🎯 옵션: 메모리 통계 조회 (디버깅/분석용)
       if (canPersistToBackend && import.meta.env.VITE_DEBUG_MODE === 'true') {
         try {
-          const statsResponse = await fetch(joinUrl(API_BASE_URL, `/memory/${sessionId}/stats`));
           const statsResponse = await fetch(`${API_BASE_URL}/api/memory/${sessionId}/stats`);
           if (statsResponse.ok) {
             const stats = await statsResponse.json();


### PR DESCRIPTION
## 🐛 문제점

빌드 오류 발생:
```
AIChat.tsx:881:14: ERROR: Expected ":" but found "response"
880 | const response = await fetch(joinUrl(API_BASE_URL, `/memory/${sessionId}/suds`), {
881 | const response = await fetch(`${API_BASE_URL}/api/memory/${sessionId}/suds`, {
```

## 🔍 근본 원인

리팩토링 중 두 가지 구현안이 동시에 남아 중복 선언 발생:
- joinUrl() 방식 (880번 줄)
- 템플릿 리터럴 방식 (881번 줄)

발생 위치: 2곳
1. SUDS 기록 API (880-881줄)
2. 메모리 통계 API (930-931줄)

## ✅ 해결 방법

joinUrl() 구현 제거, 템플릿 리터럴만 유지:
- `${API_BASE_URL}/api/memory/${sessionId}/suds`
- `${API_BASE_URL}/api/memory/${sessionId}/stats`

## 🎯 예상 결과

- ✅ 빌드 성공
- ✅ GitHub Actions 배포 정상 진행
- ✅ AI 채팅 기능 정상 작동