### PR TITLE
Fix: serverAI.ts 중복 선언 제거 (normalizeBaseUrl)

### DIFF
--- a/frontend/src/services/serverAI.ts
+++ b/frontend/src/services/serverAI.ts
@@ -71,7 +71,6 @@ const normalizeBaseUrl = (url: string) => stripTrailingSlashes(url).replace(/\/a
 
 const joinBaseWithPath = (base: string, path: string) =>
   `${stripTrailingSlashes(base)}/${path.replace(/^\/+/, '')}`;
-const normalizeBaseUrl = (url: string) => url.replace(/\/+$/, '').replace(/\/api$/, '');
 
 const rawServerUrl =
   (import.meta.env.VITE_API_BASE_URL as string | undefined) ||


### PR DESCRIPTION
## 🐛 문제점

두 번째 빌드 오류 발생:
- serverAI.ts:74:6에서 normalizeBaseUrl 중복 선언
- 70번 줄과 74번 줄에 같은 함수명 사용

## 🔍 근본 원인

리팩토링 중 normalizeBaseUrl 함수가 두 번 선언됨

## ✅ 해결 방법

74번 줄 제거, 70번 줄만 유지:
```typescript
// 70번 줄 (유지)
const normalizeBaseUrl = (url: string) => stripTrailingSlashes(url).replace(/\/api$/, '');

// 74번 줄 (제거됨)
```

## 🎯 예상 결과

- ✅ 빌드 성공
- ✅ GitHub Actions 배포 정상 진행