### PR TITLE
Fix: serverAI.ts 중복 변수 선언 제거 (4차)

### DIFF
--- a/frontend/src/services/serverAI.ts
+++ b/frontend/src/services/serverAI.ts
@@ -778,9 +778,6 @@ export async function generateReplyAB(
     max_tokens: 512,
   };
 
-  const base = resolveServerUrl();
-  const endpoint = isPremium ? '/api/chat/premium' : '/ab/chat';
-  const targetUrl = joinBaseWithPath(base, endpoint);
   const rawBase =
     (import.meta.env.VITE_API_BASE_URL as string | undefined) ||
     (import.meta.env.VITE_BACKEND_BASE as string | undefined) ||
@@ -898,9 +895,6 @@ export async function generateReplyAB_simple(message: string, isPremium: boolean
     max_tokens: 512
   };
 
-  const base = resolveServerUrl();
-  const endpoint = isPremium ? '/api/chat/premium' : '/ab/chat';
-  const targetUrl = joinBaseWithPath(base, endpoint);
   const rawBase =
     (import.meta.env.VITE_API_BASE_URL as string | undefined) ||
     (import.meta.env.VITE_BACKEND_BASE as string | undefined) ||


### PR DESCRIPTION
## Run #18440396252 빌드 실패 수정

중복 변수 선언 제거:
- base, endpoint, targetUrl이 각 함수에서 2번씩 선언됨
- resolveServerUrl() 블록 제거
- normalizeBaseUrl() 블록만 유지