### PR TITLE
fix: stabilize auth and complete install bootstrap flow

### DIFF
--- a/frontend/src/components/feature/AlarmInstallGuide.tsx
+++ b/frontend/src/components/feature/AlarmInstallGuide.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
-import { Button } from "../ui/Button";
+import { Download, QrCode, ShieldCheck, Smartphone } from "lucide-react";
+import { QRCodeCanvas } from "qrcode.react";
+
 import useInstallPrompt from "../../hooks/useInstallPrompt";
+import {
+  getInstallChannelLabel,
+  getInstallPrimaryLabel,
+  type InstallBootstrap,
+} from "../../utils/installBootstrap";
+import { Button } from "../ui/Button";
 
 interface AlarmInstallGuideProps {
   title?: string;
@@ -9,129 +17,242 @@ interface AlarmInstallGuideProps {
   installUrl?: string;
   showDismiss?: boolean;
   onDismiss?: () => void;
+  bootstrap?: InstallBootstrap | null;
+  loading?: boolean;
+  warning?: string | null;
 }
 
+const isStandalone = (): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (window.navigator as Navigator & { standalone?: boolean }).standalone === true
+  );
+};
+
+const isApkLikeUrl = (value: string): boolean =>
+  /(?:\/latest\.apk(?:$|\?)|\.apk(?:$|\?))/i.test(value.trim());
+
 export default function AlarmInstallGuide({
-  title = "알람 기능은 앱에서 안정적으로 사용해요",
-  description = "웹에서는 알람 푸시 연동이 브라우저별로 제한될 수 있어요. 앱을 설치하면 알람이 더 정확하게 동작합니다.",
+  title = "알람 기능은 앱에서 가장 안정적으로 동작합니다",
+  description = "브라우저 제약이 있는 환경에서는 앱 설치 경로와 QR 경로를 함께 준비해 두는 편이 안전합니다.",
   className = "",
   installUrl,
   showDismiss = false,
   onDismiss,
+  bootstrap,
+  loading = false,
+  warning,
 }: AlarmInstallGuideProps) {
   const { supported, promptInstall } = useInstallPrompt();
   const [copied, setCopied] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [isInstalled, setIsInstalled] = useState(false);
 
-  const targetUrl = useMemo(() => (installUrl || "").trim(), [installUrl]);
-  const isApkLikeUrl = useMemo(
-    () => /(?:\/latest\.apk(?:$|\?)|\.apk(?:$|\?))/i.test(targetUrl),
-    [targetUrl]
-  );
-
-  const qrUrl = useMemo(
-    () =>
-      isApkLikeUrl && targetUrl
-        ? `https://api.qrserver.com/v1/create-qr-code/?size=160x160&margin=1&format=png&data=${encodeURIComponent(
-            targetUrl
-          )}`
-        : "",
-    [isApkLikeUrl, targetUrl]
-  );
-
   useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const mediaQueryMatch = window.matchMedia("(display-mode: standalone)").matches;
-    const iosStandalone = (window.navigator as any).standalone === true;
-    setIsInstalled(mediaQueryMatch || iosStandalone);
+    const updateInstalledState = () => {
+      setIsInstalled(isStandalone());
+    };
+
+    updateInstalledState();
+    window.addEventListener("appinstalled", updateInstalledState);
+
+    return () => {
+      window.removeEventListener("appinstalled", updateInstalledState);
+    };
   }, []);
 
+  const resolvedInstallUrl = useMemo(
+    () => (bootstrap?.installUrl ?? installUrl ?? "").trim(),
+    [bootstrap?.installUrl, installUrl]
+  );
+  const fallbackInstallUrl = useMemo(
+    () => (bootstrap?.fallbackUrl ?? resolvedInstallUrl).trim(),
+    [bootstrap?.fallbackUrl, resolvedInstallUrl]
+  );
+  const qrValue = useMemo(
+    () => (bootstrap?.qrPayload || resolvedInstallUrl || fallbackInstallUrl).trim(),
+    [bootstrap?.qrPayload, fallbackInstallUrl, resolvedInstallUrl]
+  );
+  const copyValue = qrValue || resolvedInstallUrl || fallbackInstallUrl;
+  const channel = bootstrap?.channel ?? (isApkLikeUrl(resolvedInstallUrl) ? "apk" : "unknown");
+  const primaryLabel = bootstrap
+    ? getInstallPrimaryLabel(channel)
+    : isApkLikeUrl(resolvedInstallUrl)
+      ? "APK 열기"
+      : "설치 링크 열기";
+  const channelLabel = bootstrap
+    ? getInstallChannelLabel(channel)
+    : isApkLikeUrl(resolvedInstallUrl)
+      ? "Direct APK"
+      : "Install link";
+  const canPromptInstall =
+    supported ||
+    (typeof window !== "undefined" && typeof window.promptAppInstall === "function");
+  const effectiveWarning =
+    warning ??
+    (!resolvedInstallUrl && !fallbackInstallUrl
+      ? "설치 링크가 아직 준비되지 않았습니다. 환경변수 또는 설치 매니페스트를 확인해 주세요."
+      : null);
+  const metadataSummary = [
+    bootstrap?.versionName ? `v${bootstrap.versionName}` : null,
+    bootstrap?.buildId ? `build ${bootstrap.buildId}` : null,
+    bootstrap?.updatedAt ? bootstrap.updatedAt : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
   const handleInstall = async () => {
-    if (!supported) return;
+    if (!canPromptInstall) {
+      return;
+    }
+
     setInstalling(true);
     try {
-      await promptInstall();
+      if (typeof window !== "undefined" && typeof window.promptAppInstall === "function") {
+        await window.promptAppInstall();
+      } else {
+        await promptInstall();
+      }
     } finally {
       setInstalling(false);
     }
   };
 
   const handleCopy = async () => {
-    if (!targetUrl || typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+    if (!copyValue || typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
       return;
     }
 
     try {
-      await navigator.clipboard.writeText(targetUrl);
+      await navigator.clipboard.writeText(copyValue);
       setCopied(true);
-      setTimeout(() => setCopied(false), 1800);
+      window.setTimeout(() => setCopied(false), 1800);
     } catch (error) {
-      console.error("QR URL copy failed:", error);
+      console.error("Failed to copy install link:", error);
     }
   };
 
-  if (isInstalled) {
+  if (isInstalled || (bootstrap?.source === "manifest" && !resolvedInstallUrl && !fallbackInstallUrl)) {
     return null;
   }
 
   return (
     <div
-      className={`rounded-2xl border border-amber-200 bg-gradient-to-r from-amber-50 to-yellow-50 p-4 ${className}`}
+      className={`rounded-3xl border border-amber-200 bg-gradient-to-br from-amber-50 via-white to-yellow-50 p-5 shadow-sm ${className}`}
     >
       {showDismiss && (
         <div className="flex justify-end">
           <button
             type="button"
             onClick={onDismiss}
-            className="text-xs text-gray-500 hover:text-gray-700"
+            className="text-xs font-medium text-slate-500 transition hover:text-slate-700"
           >
             닫기
           </button>
         </div>
       )}
-      <h4 className="text-sm font-bold text-gray-900">{title}</h4>
-      <p className="mt-1 text-xs leading-relaxed text-gray-700">{description}</p>
-      {targetUrl && !isApkLikeUrl && (
-        <p className="mt-2 text-xs text-red-700">
-          설치 URL이 APK 경로가 아닙니다. (/latest.apk 또는 .apk URL 필요)
-        </p>
-      )}
 
-      <div className="mt-3 flex flex-wrap gap-2">
-        {supported && (
-          <Button size="sm" onClick={handleInstall} className="bg-amber-600 hover:bg-amber-700" disabled={installing}>
-            {installing ? "설치 시도 중..." : "지금 웹앱(PWA) 설치"}
-          </Button>
-        )}
-        {!supported && targetUrl && isApkLikeUrl && (
-          <a
-            href={targetUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex rounded border border-amber-300 bg-white px-3 py-2 text-xs text-amber-800 hover:bg-amber-100"
-          >
-            현재 링크로 접속
-          </a>
-        )}
-        <button
-          type="button"
-          onClick={handleCopy}
-          className="inline-flex items-center rounded border border-amber-300 bg-white px-3 py-2 text-xs text-gray-700 hover:bg-amber-100"
-        >
-          {copied ? "복사됨" : "URL 복사"}
-        </button>
+      <div className="flex items-start gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-amber-100 text-amber-700">
+          <Smartphone className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h4 className="text-sm font-semibold text-slate-950">{title}</h4>
+          <p className="mt-1 text-sm leading-6 text-slate-600">{description}</p>
+          <div className="mt-3 flex flex-wrap gap-2 text-xs">
+            <span className="rounded-full bg-amber-100 px-2.5 py-1 font-medium text-amber-800">
+              {channelLabel}
+            </span>
+            {bootstrap?.source && (
+              <span className="rounded-full bg-slate-100 px-2.5 py-1 font-medium text-slate-700">
+                {bootstrap.source === "manifest" ? "Manifest" : "Fallback"}
+              </span>
+            )}
+            {metadataSummary && (
+              <span className="rounded-full bg-emerald-100 px-2.5 py-1 font-medium text-emerald-800">
+                {metadataSummary}
+              </span>
+            )}
+          </div>
+          {loading && (
+            <p className="mt-3 text-xs text-slate-500">설치 메타데이터를 확인하는 중입니다.</p>
+          )}
+          {effectiveWarning && (
+            <p className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+              {effectiveWarning}
+            </p>
+          )}
+        </div>
       </div>
 
-      {qrUrl && (
-        <div className="mt-3 flex items-center gap-3">
-          <img src={qrUrl} alt="앱 설치 QR" className="h-28 w-28 rounded border bg-white" />
-          <div className="text-xs text-gray-700">
-            휴대폰으로 QR을 찍어 앱 설치 링크를 열어주세요.
-            <br />
-            홈 화면 추가(설치) 또는 앱 설치 버튼을 눌러 주세요.
+      <div className="mt-4 flex flex-wrap gap-2">
+        {canPromptInstall && (
+          <Button
+            size="sm"
+            onClick={() => {
+              void handleInstall();
+            }}
+            className="bg-amber-600 hover:bg-amber-700"
+            disabled={installing}
+          >
+            {installing ? "설치 확인 중..." : "웹앱 설치"}
+          </Button>
+        )}
+
+        {resolvedInstallUrl && (
+          <a
+            href={resolvedInstallUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-medium text-amber-900 transition hover:bg-amber-100"
+          >
+            <Download className="h-4 w-4" />
+            {primaryLabel}
+          </a>
+        )}
+
+        {fallbackInstallUrl && fallbackInstallUrl !== resolvedInstallUrl && (
+          <a
+            href={fallbackInstallUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+          >
+            <ShieldCheck className="h-4 w-4" />
+            대체 설치 경로
+          </a>
+        )}
+
+        {copyValue && (
+          <button
+            type="button"
+            onClick={() => {
+              void handleCopy();
+            }}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+          >
+            <QrCode className="h-4 w-4" />
+            {copied ? "복사됨" : "설치 링크 복사"}
+          </button>
+        )}
+      </div>
+
+      {qrValue && (
+        <div className="mt-4 flex flex-col gap-3 rounded-2xl border border-amber-100 bg-white/90 p-4 sm:flex-row sm:items-center">
+          <div className="flex h-28 w-28 items-center justify-center rounded-2xl border border-slate-200 bg-white">
+            <QRCodeCanvas value={qrValue} size={96} level="M" includeMargin />
+          </div>
+          <div className="min-w-0 flex-1 text-sm text-slate-600">
+            <div className="font-medium text-slate-900">모바일에서 바로 여는 QR</div>
+            <p className="mt-1 leading-6">
+              휴대폰으로 QR을 스캔해 설치 경로를 바로 열 수 있습니다. 브라우저에서
+              열기 어렵다면 설치 링크 복사 버튼을 함께 사용해 주세요.
+            </p>
+            <div className="mt-2 break-all text-xs text-slate-500">{qrValue}</div>
           </div>
         </div>
       )}

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -4,83 +4,110 @@ import { Link, NavLink, useLocation } from "react-router-dom";
 import { useDeadlineGoals } from "../../hooks/useDeadlineGoals";
 import useInstallPrompt from "../../hooks/useInstallPrompt";
 import { useAuth } from "../../hooks/useAuth";
-import { buildPlannerHref } from "../../utils/plannerRoutes";
+import { buildAddAlarmHref, buildPlannerHref } from "../../utils/plannerRoutes";
 
 const LINK_CLASS =
-  "rounded-full px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900";
+  "inline-flex items-center rounded-full border border-transparent px-3.5 py-2 text-sm font-medium text-slate-600 transition duration-200";
+
+const getLinkClassName = (isActive: boolean) =>
+  `${LINK_CLASS} ${
+    isActive
+      ? "border-slate-900/10 bg-slate-950 text-white shadow-[0_16px_30px_rgba(15,23,42,0.18)]"
+      : "hover:border-slate-200 hover:bg-white hover:text-slate-950"
+  }`;
 
 export default function AppHeader() {
   const location = useLocation();
   const { supported, promptInstall } = useInstallPrompt();
   const { user } = useAuth();
   const { todayHeadline, toggleItem, pullForward } = useDeadlineGoals(user?.uid);
-  const plannerSearchParams = location.pathname === "/planner" ? location.search : undefined;
+  const plannerSearchParams =
+    location.pathname === "/planner" || location.pathname === "/add-alarm"
+      ? location.search
+      : undefined;
 
   return (
-    <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/95 shadow-sm backdrop-blur">
+    <header className="sticky top-0 z-40 border-b border-white/50 bg-[linear-gradient(180deg,_rgba(248,251,255,0.92),_rgba(255,255,255,0.82))] backdrop-blur-xl">
       <div className="mx-auto max-w-6xl px-4 py-3 sm:px-6">
         <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-wrap items-center gap-2">
-              <NavLink
-                to="/signal-inbox"
-                className={({ isActive }) =>
-                  `${LINK_CLASS} ${isActive ? "bg-sky-50 text-sky-700" : ""}`
-                }
-              >
-                신호함
-              </NavLink>
-              <NavLink
-                to={buildPlannerHref("alarm", { baseSearchParams: plannerSearchParams })}
-                className={({ isActive }) =>
-                  `${LINK_CLASS} ${isActive ? "bg-sky-50 text-sky-700" : ""}`
-                }
-              >
-                플래너
-              </NavLink>
-              <NavLink
-                to="/my-page"
-                className={({ isActive }) =>
-                  `${LINK_CLASS} ${isActive ? "bg-sky-50 text-sky-700" : ""}`
-                }
-              >
-                마이페이지
-              </NavLink>
-            </div>
+          <div className="rounded-[30px] border border-white/70 bg-white/80 p-3 shadow-[0_20px_50px_rgba(15,23,42,0.08)] backdrop-blur">
+            <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+              <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:gap-4">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950 text-white shadow-[0_18px_40px_rgba(15,23,42,0.2)]">
+                    <Sparkles className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+                      Production Flow
+                    </div>
+                    <div className="text-sm font-semibold text-slate-950">EFT Control Surface</div>
+                  </div>
+                </div>
 
-            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-              <Link
-                to="/mobile-link"
-                className="rounded-full border border-slate-300 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-              >
-                모바일 QR 로그인
-              </Link>
-              {supported && (
-                <button
-                  type="button"
-                  onClick={async () => {
-                    await promptInstall();
-                  }}
-                  className="rounded-full bg-sky-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-sky-700"
+                <div className="flex flex-wrap items-center gap-2">
+                  <NavLink
+                    to="/signal-inbox"
+                    className={({ isActive }) => getLinkClassName(isActive)}
+                  >
+                    Signal Inbox
+                  </NavLink>
+                  <NavLink
+                    to={buildPlannerHref("today", { baseSearchParams: plannerSearchParams })}
+                    className={({ isActive }) => getLinkClassName(isActive)}
+                  >
+                    Planner
+                  </NavLink>
+                  <NavLink
+                    to={buildAddAlarmHref({ baseSearchParams: plannerSearchParams })}
+                    className={({ isActive }) => getLinkClassName(isActive)}
+                  >
+                    Alarm Studio
+                  </NavLink>
+                  <NavLink
+                    to="/my-page"
+                    className={({ isActive }) => getLinkClassName(isActive)}
+                  >
+                    My Page
+                  </NavLink>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2 xl:justify-end">
+                <Link
+                  to="/mobile-link"
+                  className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3.5 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:text-slate-950"
                 >
-                  앱 설치
-                </button>
-              )}
+                  Mobile QR Login
+                </Link>
+                {supported && (
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      const result = await promptInstall();
+                      console.log("PWA install outcome:", result?.outcome);
+                    }}
+                    className="inline-flex items-center rounded-full bg-slate-950 px-3.5 py-2 text-sm font-medium text-white shadow-[0_18px_40px_rgba(15,23,42,0.18)] transition hover:-translate-y-0.5 hover:bg-slate-900"
+                  >
+                    Install App
+                  </button>
+                )}
+              </div>
             </div>
           </div>
 
           {todayHeadline && (
-            <div className="rounded-[28px] border border-slate-200 bg-[linear-gradient(135deg,_rgba(14,165,233,0.12),_rgba(255,255,255,0.96)_48%,_rgba(16,185,129,0.12))] p-4 shadow-sm">
-              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-                <div className="space-y-2">
+            <div className="rounded-[32px] border border-white/70 bg-[linear-gradient(135deg,_rgba(14,165,233,0.14),_rgba(255,255,255,0.98)_48%,_rgba(16,185,129,0.12))] p-5 shadow-[0_20px_50px_rgba(15,23,42,0.08)]">
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div className="space-y-2.5">
                   <div className="flex flex-wrap items-center gap-2">
                     <span className="inline-flex items-center gap-1 rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold text-sky-700">
                       <Sparkles className="h-3.5 w-3.5" />
-                      오늘의 마감 헤드라인
+                      Live Deadline Signal
                     </span>
                     <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
                       <Egg className="h-3.5 w-3.5" />
-                      부화 확률 {todayHeadline.summary.hatchProbability}%
+                      Hatch Probability {todayHeadline.summary.hatchProbability}%
                     </span>
                   </div>
                   <div>
@@ -91,7 +118,8 @@ export default function AppHeader() {
                       {todayHeadline.summary.dDay >= 0
                         ? `D-${todayHeadline.summary.dDay}`
                         : `D+${Math.abs(todayHeadline.summary.dDay)}`}{" "}
-                      · {todayHeadline.summary.completedCount}/{todayHeadline.summary.totalCount} 완료
+                      completed {todayHeadline.summary.completedCount}/
+                      {todayHeadline.summary.totalCount}
                     </div>
                   </div>
                 </div>
@@ -100,9 +128,9 @@ export default function AppHeader() {
                   to={buildPlannerHref("deadline", {
                     baseSearchParams: plannerSearchParams,
                   })}
-                  className="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-sky-300 hover:text-sky-700"
+                  className="inline-flex items-center justify-center rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300 hover:text-sky-700"
                 >
-                  전체 목표 보기
+                  Open Deadline Engine
                 </Link>
               </div>
 
@@ -114,7 +142,7 @@ export default function AppHeader() {
                     onClick={() => {
                       void toggleItem(todayHeadline.plan.id, item.id);
                     }}
-                    className="flex w-full items-start gap-3 rounded-2xl border border-slate-200 bg-white/90 px-4 py-3 text-left transition hover:border-sky-300 hover:bg-sky-50"
+                    className="flex w-full items-start gap-3 rounded-[24px] border border-slate-200 bg-white/90 px-4 py-3 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300 hover:bg-sky-50"
                   >
                     <div
                       className={`mt-0.5 flex h-5 w-5 items-center justify-center rounded-full border ${
@@ -128,15 +156,15 @@ export default function AppHeader() {
                     <div className="flex-1">
                       <div className="text-sm font-medium text-slate-900">{item.title}</div>
                       <div className="mt-1 text-xs text-slate-500">
-                        {item.estMinutes}분 · {item.lane === "overdue" ? "이월 분량" : "오늘 분량"}
+                        {item.estMinutes} min {item.lane === "overdue" ? "overdue" : "today"}
                       </div>
                     </div>
                   </button>
                 ))}
 
                 {todayHeadline.agenda.pendingItems.length === 0 && (
-                  <div className="rounded-2xl border border-dashed border-slate-200 bg-white/80 px-4 py-4 text-sm text-slate-500">
-                    오늘 체크리스트를 모두 완료했습니다.
+                  <div className="rounded-[24px] border border-dashed border-slate-200 bg-white/80 px-4 py-4 text-sm text-slate-500">
+                    Today's visible checklist is complete.
                   </div>
                 )}
               </div>
@@ -144,25 +172,25 @@ export default function AppHeader() {
               {todayHeadline.agenda.allVisibleDone &&
                 todayHeadline.agenda.remainingCapacityMinutes > 0 &&
                 todayHeadline.agenda.nextItems.length > 0 && (
-                  <div className="mt-4 flex flex-col gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="mt-4 flex flex-col gap-3 rounded-[24px] border border-emerald-200 bg-emerald-50 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
                     <div>
                       <div className="text-sm font-semibold text-emerald-900">
-                        시간이 남아 있습니다.
+                        Capacity is still available.
                       </div>
                       <div className="mt-1 text-xs text-emerald-700">
-                        내일 분량 {todayHeadline.agenda.nextItems.length}개를 앞으로 당길 수 있습니다.
+                        You can pull {todayHeadline.agenda.nextItems.length} future items into today.
                       </div>
                     </div>
                     <button
                       type="button"
                       onClick={() => {
-                        if (window.confirm("내일 분량을 오늘로 당길까요?")) {
+                        if (window.confirm("Pull future items into today?")) {
                           void pullForward(todayHeadline.plan.id);
                         }
                       }}
-                      className="rounded-2xl bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-700"
+                      className="rounded-2xl bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-emerald-700"
                     >
-                      내일 분량 당기기
+                      Pull Forward
                     </button>
                   </div>
                 )}

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -59,8 +59,7 @@ export default function AppHeader() {
                 <button
                   type="button"
                   onClick={async () => {
-                    const result = await promptInstall();
-                    console.log("PWA install outcome:", result?.outcome);
+                    await promptInstall();
                   }}
                   className="rounded-full bg-sky-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-sky-700"
                 >

--- a/frontend/src/components/layout/BottomNav.tsx
+++ b/frontend/src/components/layout/BottomNav.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BellPlus, Inbox, UserRound } from "lucide-react";
+import { BellPlus, CalendarClock, Inbox, UserRound } from "lucide-react";
 
 interface BottomNavProps {
   activeTab: string;
@@ -10,18 +10,27 @@ interface BottomNavProps {
 const NAV_ITEMS = [
   {
     id: "home",
-    label: "신호함",
+    label: "Signals",
     icon: Inbox,
+    accent: "from-sky-400 via-cyan-300 to-sky-400",
+  },
+  {
+    id: "planner",
+    label: "Planner",
+    icon: CalendarClock,
+    accent: "from-sky-400 via-cyan-300 to-emerald-300",
   },
   {
     id: "addAlarm",
-    label: "알람 추가",
+    label: "Alarm",
     icon: BellPlus,
+    accent: "from-amber-300 via-orange-300 to-rose-300",
   },
   {
     id: "myPage",
-    label: "마이페이지",
+    label: "My",
     icon: UserRound,
+    accent: "from-emerald-300 via-teal-300 to-cyan-300",
   },
 ] as const;
 
@@ -32,9 +41,9 @@ const BottomNav: React.FC<BottomNavProps> = ({
 }) => {
   return (
     <nav
-      className={`border-t border-slate-200 bg-white/95 px-3 py-2 shadow-[0_-10px_30px_rgba(15,23,42,0.08)] backdrop-blur ${className}`}
+      className={`mx-auto max-w-xl rounded-[30px] border border-white/70 bg-[linear-gradient(180deg,_rgba(255,255,255,0.92),_rgba(248,250,252,0.84))] p-2 shadow-[0_24px_70px_rgba(15,23,42,0.16)] backdrop-blur-xl ${className}`}
     >
-      <div className="mx-auto flex max-w-md justify-around gap-2">
+      <div className="grid grid-cols-4 gap-2">
         {NAV_ITEMS.map((item) => {
           const isActive = activeTab === item.id;
           const Icon = item.icon;
@@ -44,14 +53,25 @@ const BottomNav: React.FC<BottomNavProps> = ({
               key={item.id}
               type="button"
               onClick={() => onTabChange(item.id)}
-              className={`flex min-w-[88px] flex-col items-center rounded-2xl px-3 py-2 text-xs font-semibold transition ${
+              className={`group relative flex min-w-0 flex-col items-center overflow-hidden rounded-[22px] px-2 py-2.5 text-[11px] font-semibold transition ${
                 isActive
-                  ? "bg-sky-50 text-sky-700"
-                  : "text-slate-500 hover:bg-slate-50 hover:text-slate-900"
+                  ? "bg-slate-950 text-white shadow-[0_18px_30px_rgba(15,23,42,0.18)]"
+                  : "text-slate-500 hover:bg-white/85 hover:text-slate-900"
               }`}
             >
-              <Icon className={`h-5 w-5 ${isActive ? "scale-105" : ""}`} />
-              <span className="mt-1">{item.label}</span>
+              {isActive && (
+                <span
+                  className={`absolute inset-x-3 top-0 h-px bg-gradient-to-r ${item.accent}`}
+                />
+              )}
+              <div
+                className={`flex h-9 w-9 items-center justify-center rounded-2xl transition ${
+                  isActive ? "bg-white/10" : "bg-slate-100 group-hover:bg-slate-200"
+                }`}
+              >
+                <Icon className={`h-5 w-5 ${isActive ? "scale-105" : ""}`} />
+              </div>
+              <span className="mt-1 truncate">{item.label}</span>
             </button>
           );
         })}

--- a/frontend/src/components/layout/LayoutController.tsx
+++ b/frontend/src/components/layout/LayoutController.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+
 import { useAuth } from "../../hooks/useAuth";
-import { buildPlannerHref } from "../../utils/plannerRoutes";
+import { buildAddAlarmHref, buildPlannerHref } from "../../utils/plannerRoutes";
 import AppHeader from "./AppHeader";
 import BottomNav from "./BottomNav";
 
@@ -11,6 +12,12 @@ const LayoutController: React.FC<{ children: React.ReactNode }> = ({ children })
   const navigate = useNavigate();
 
   const isLandingPage = location.pathname === "/";
+  const plannerContextRoutes = new Set([
+    "/planner",
+    "/add-alarm",
+    "/deadline-planner",
+    "/plan/day",
+  ]);
   const navRoutes = new Set([
     "/signal-inbox",
     "/planner",
@@ -18,31 +25,39 @@ const LayoutController: React.FC<{ children: React.ReactNode }> = ({ children })
     "/deadline-planner",
     "/plan/day",
     "/my-page",
+    "/profile-setup",
   ]);
   const isNavPage = navRoutes.has(location.pathname);
 
   const getActiveTab = (pathname: string) => {
-    if (pathname === "/planner") return "addAlarm";
+    if (pathname === "/planner" || pathname === "/deadline-planner" || pathname === "/plan/day") {
+      return "planner";
+    }
     if (pathname === "/add-alarm") return "addAlarm";
-    if (pathname === "/deadline-planner") return "addAlarm";
-    if (pathname === "/plan/day") return "addAlarm";
-    if (pathname === "/my-page") return "myPage";
+    if (pathname === "/my-page" || pathname === "/profile-setup") return "myPage";
     return "home";
   };
 
   const onTabChange = (tabId: string) => {
-    if (tabId === "addAlarm") {
-      navigate(
-        buildPlannerHref("alarm", {
-          baseSearchParams: location.pathname === "/planner" ? location.search : undefined,
-        })
-      );
+    const baseSearchParams = plannerContextRoutes.has(location.pathname)
+      ? location.search
+      : undefined;
+
+    if (tabId === "planner") {
+      navigate(buildPlannerHref("today", { baseSearchParams }));
       return;
     }
+
+    if (tabId === "addAlarm") {
+      navigate(buildAddAlarmHref({ baseSearchParams }));
+      return;
+    }
+
     if (tabId === "myPage") {
       navigate("/my-page");
       return;
     }
+
     navigate("/signal-inbox");
   };
 
@@ -51,7 +66,7 @@ const LayoutController: React.FC<{ children: React.ReactNode }> = ({ children })
       {!isLandingPage && isAuthenticated && <AppHeader />}
       <div className={isNavPage ? "pb-20" : undefined}>{children}</div>
       {isAuthenticated && isNavPage && (
-        <div className="fixed bottom-0 left-0 right-0 z-50">
+        <div className="fixed inset-x-0 bottom-0 z-50 px-4 pb-4">
           <BottomNav activeTab={getActiveTab(location.pathname)} onTabChange={onTabChange} />
         </div>
       )}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,7 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
-import { signOut } from 'firebase/auth';
-import { resolveBackendUrl } from '@/services/http';
-import { auth } from '@/firebase/config';
+import type { Dispatch, SetStateAction } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { signOut } from "firebase/auth";
+
+import { auth } from "@/firebase/config";
+import { loadBackendSessionUser } from "@/services/authSession";
+import { resolveBackendUrl } from "@/services/http";
 
 interface EFTUser {
   uid: string;
@@ -24,68 +27,130 @@ interface EFTUser {
   unlockedInsights: string[];
 }
 
-export const useAuth = () => {
-  const [user, setUser] = useState<EFTUser | null>(null);
-  const [loading, setLoading] = useState(true);
+type AuthSnapshot = {
+  user: EFTUser | null;
+  loading: boolean;
+  hydrated: boolean;
+};
 
-  const hydrateFromBackend = useCallback(async () => {
-    setLoading(true);
+const listeners = new Set<Dispatch<SetStateAction<AuthSnapshot>>>();
+
+let authSnapshot: AuthSnapshot = {
+  user: null,
+  loading: true,
+  hydrated: false,
+};
+
+let hydratePromise: Promise<void> | null = null;
+
+const emitSnapshot = () => {
+  const next = authSnapshot;
+  listeners.forEach((listener) => listener(next));
+};
+
+const setAuthSnapshot = (next: AuthSnapshot) => {
+  authSnapshot = next;
+  emitSnapshot();
+};
+
+const mapBackendUser = (user: NonNullable<Awaited<ReturnType<typeof loadBackendSessionUser>>>) => ({
+  uid: user.id,
+  email: user.email ?? null,
+  name: user.name ?? null,
+  photoURL: user.photo_url ?? null,
+  level: 1,
+  xp: 0,
+  nextLevelXp: 100,
+  gems: 50,
+  badges: 0,
+  streak: 0,
+  createdAt: new Date(),
+  lastLogin: new Date(),
+  privacySettings: { dataCollection: true, aiLearning: true },
+  completedQuests: [],
+  unlockedInsights: [],
+});
+
+const hydrateAuthState = async (force = false) => {
+  if (!force && hydratePromise) {
+    return hydratePromise;
+  }
+
+  const run = async () => {
+    setAuthSnapshot({
+      ...authSnapshot,
+      loading: true,
+    });
+
     try {
-      const res = await fetch(resolveBackendUrl('/api/auth/me'), { credentials: 'include' });
-      const data = await res.json();
-      if (res.ok && data?.authenticated && data?.user) {
-        setUser({
-          uid: data.user.id,
-          email: data.user.email ?? null,
-          name: data.user.name ?? null,
-          photoURL: data.user.photo_url ?? null,
-          level: 1,
-          xp: 0,
-          nextLevelXp: 100,
-          gems: 50,
-          badges: 0,
-          streak: 0,
-          createdAt: new Date(),
-          lastLogin: new Date(),
-          privacySettings: { dataCollection: true, aiLearning: true },
-          completedQuests: [],
-          unlockedInsights: [],
-        });
-      } else {
-        setUser(null);
-      }
+      const backendUser = await loadBackendSessionUser({ allowRefresh: true });
+      setAuthSnapshot({
+        user: backendUser ? mapBackendUser(backendUser) : null,
+        loading: false,
+        hydrated: true,
+      });
     } catch {
-      setUser(null);
-    } finally {
-      setLoading(false);
+      setAuthSnapshot({
+        user: null,
+        loading: false,
+        hydrated: true,
+      });
     }
-  }, []);
+  };
+
+  hydratePromise = run().finally(() => {
+    hydratePromise = null;
+  });
+
+  return hydratePromise;
+};
+
+export const useAuth = () => {
+  const [snapshot, setSnapshot] = useState<AuthSnapshot>(authSnapshot);
 
   useEffect(() => {
-    hydrateFromBackend();
-  }, [hydrateFromBackend]);
+    listeners.add(setSnapshot);
+    setSnapshot(authSnapshot);
+    if (!authSnapshot.hydrated && !hydratePromise) {
+      void hydrateAuthState();
+    }
+    return () => {
+      listeners.delete(setSnapshot);
+    };
+  }, []);
 
   const logout = useCallback(async () => {
     try {
-      await fetch(resolveBackendUrl('/api/auth/logout'), { method: 'POST', credentials: 'include' });
+      await fetch(resolveBackendUrl("/api/auth/logout"), {
+        method: "POST",
+        credentials: "include",
+      });
     } finally {
       try {
         await signOut(auth);
       } catch {
         // Ignore local Firebase sign-out failures and still clear app state.
       }
-      sessionStorage.removeItem('auth_mode');
-      sessionStorage.removeItem('auth_marketing');
-      sessionStorage.removeItem('auth_connect_notion');
-      setUser(null);
+      sessionStorage.removeItem("auth_mode");
+      sessionStorage.removeItem("auth_marketing");
+      sessionStorage.removeItem("auth_connect_notion");
+      setAuthSnapshot({
+        user: null,
+        loading: false,
+        hydrated: true,
+      });
     }
   }, []);
 
+  const refresh = useCallback(async () => {
+    await hydrateAuthState(true);
+  }, []);
+
   return {
-    user,
-    loading,
-    isAuthenticated: !!user,
+    user: snapshot.user,
+    loading: snapshot.loading,
+    isAuthenticated: !!snapshot.user,
     logout,
-    refresh: hydrateFromBackend,
+    refresh,
   };
 };

--- a/frontend/src/hooks/useGoogleCalendar.ts
+++ b/frontend/src/hooks/useGoogleCalendar.ts
@@ -48,7 +48,7 @@ interface UseGoogleCalendarResult {
 }
 
 export function useGoogleCalendar(): UseGoogleCalendarResult {
-  const { user } = useAuth();
+  const { user, loading: authLoading } = useAuth();
   const [isConnected, setIsConnected] = useState(false);
   const [googleEvents, setGoogleEvents] = useState<GoogleCalendarEvent[]>([]);
   const [lastSync, setLastSync] = useState<Date | null>(null);
@@ -64,12 +64,26 @@ export function useGoogleCalendar(): UseGoogleCalendarResult {
 
   // 초기 연결 상태 확인
   useEffect(() => {
+    if (authLoading) return;
+    if (!user?.uid) {
+      setIsConnected(false);
+      setGoogleEvents([]);
+      setLastSync(null);
+      return;
+    }
+
     let cancelled = false;
     (async () => {
       try {
         const res = await fetch(resolveBackendUrl("/api/spec/google/status"), {
           credentials: "include",
         });
+        if (res.status === 401 || res.status === 403) {
+          if (!cancelled) {
+            setIsConnected(false);
+          }
+          return;
+        }
         if (!res.ok) return;
         const data = (await res.json()) as { connected?: boolean };
         if (!cancelled) {
@@ -82,10 +96,14 @@ export function useGoogleCalendar(): UseGoogleCalendarResult {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [authLoading, user?.uid]);
 
   const connectGoogle = useCallback(async () => {
     setError(null);
+    if (!user?.uid) {
+      redirectToLogin();
+      return;
+    }
     try {
       const nextPath = window.location.pathname;
       const authPath = `/api/spec/google/auth?next=${encodeURIComponent(nextPath)}`;
@@ -110,7 +128,7 @@ export function useGoogleCalendar(): UseGoogleCalendarResult {
       console.error("Google 연동 시작 실패:", e);
       setError("Google 캘린더 연동을 시작할 수 없습니다.");
     }
-  }, []);
+  }, [user?.uid]);
 
   const fetchGoogleEvents = useCallback(async (dateIso: string) => {
     setLoading(true);

--- a/frontend/src/hooks/useInstallPrompt.ts
+++ b/frontend/src/hooks/useInstallPrompt.ts
@@ -1,32 +1,52 @@
 import { useEffect, useState } from "react";
 
+type PromptChoice = {
+  outcome: "accepted" | "dismissed";
+  platform?: string;
+};
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<PromptChoice>;
+}
+
+export type InstallPromptResult = {
+  outcome: "accepted" | "dismissed" | "unavailable" | "error";
+};
+
 export default function useInstallPrompt() {
-  const [deferred, setDeferred] = useState<any>(null);
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
   const [supported, setSupported] = useState(false);
 
   useEffect(() => {
-    const handler = (e: any) => {
-      console.log('🎉 beforeinstallprompt 이벤트 발생!', e);
-      e.preventDefault();           // 기본 배너 막고
-      setDeferred(e);               // 이벤트 저장
+    const handler = (event: Event) => {
+      const promptEvent = event as BeforeInstallPromptEvent;
+      promptEvent.preventDefault();
+      setDeferred(promptEvent);
       setSupported(true);
-      console.log('✅ PWA 설치 버튼 활성화됨');
     };
 
-    window.addEventListener("beforeinstallprompt", handler as any);
-    console.log('📱 beforeinstallprompt 리스너 등록됨');
+    window.addEventListener("beforeinstallprompt", handler);
 
     return () => {
-      window.removeEventListener("beforeinstallprompt", handler as any);
-      console.log('🧹 beforeinstallprompt 리스너 정리됨');
+      window.removeEventListener("beforeinstallprompt", handler);
     };
   }, []);
 
-  const promptInstall = async () => {
-    if (!deferred) return { outcome: "dismissed" as const };
-    const res = await deferred.prompt(); // 반드시 사용자 제스처 안에서 호출!
-    setDeferred(null);                   // 한 번 쓰면 보통 소멸
-    return res;
+  const promptInstall = async (): Promise<InstallPromptResult> => {
+    if (!deferred) {
+      return { outcome: "unavailable" };
+    }
+
+    try {
+      await deferred.prompt();
+      const choice = await deferred.userChoice;
+      setDeferred(null);
+      setSupported(false);
+      return { outcome: choice?.outcome ?? "accepted" };
+    } catch {
+      return { outcome: "error" };
+    }
   };
 
   return { supported, promptInstall };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { API_CONFIG, resolveBackendUrl, isApiPath } from "./config/api";
+import { refreshBackendSession } from "./services/authSession";
 
 declare const __BUILD_ID__: string
 declare const __BUILD_TIME__: string
@@ -68,6 +69,30 @@ const shouldAttachApiCredentials = (rawUrl: string): boolean => {
   }
 }
 
+const shouldRetryWithRefresh = (requestUrl: URL): boolean => {
+  if (!isApiPath(requestUrl.pathname)) {
+    return false
+  }
+  return !/^\/api\/auth\/(login|logout|refresh|me)(\/|$)/.test(requestUrl.pathname)
+}
+
+const fetchWithRefreshRetry = async (
+  requestUrl: URL,
+  execute: () => Promise<Response>
+): Promise<Response> => {
+  const response = await execute()
+  if (response.status !== 401 || !shouldRetryWithRefresh(requestUrl)) {
+    return response
+  }
+
+  const refreshed = await refreshBackendSession()
+  if (!refreshed) {
+    return response
+  }
+
+  return execute()
+}
+
 window.fetch = async (input: RequestInfo, init?: RequestInit) => {
   try {
     // PRODUCTION SAFETY:
@@ -79,15 +104,19 @@ window.fetch = async (input: RequestInfo, init?: RequestInit) => {
         if (!isAbsoluteUrl(value)) {
           const requestUrl = new URL(value, window.location.origin)
           if (isApiPath(requestUrl.pathname)) {
-            return originalFetch(requestUrl.pathname + requestUrl.search, withApiCredentials(init))
+            return fetchWithRefreshRetry(requestUrl, () =>
+              originalFetch(requestUrl.pathname + requestUrl.search, withApiCredentials(init))
+            )
           }
         }
       } else if (input instanceof Request) {
         try {
           const requestUrl = new URL(input.url)
           if (requestUrl.origin === window.location.origin && isApiPath(requestUrl.pathname)) {
-            const rewrittenRequest = new Request(requestUrl.pathname + requestUrl.search, input)
-            return originalFetch(rewrittenRequest, withApiCredentials(init))
+            return fetchWithRefreshRetry(requestUrl, () => {
+              const rewrittenRequest = new Request(requestUrl.pathname + requestUrl.search, input.clone())
+              return originalFetch(rewrittenRequest, withApiCredentials(init))
+            })
           }
         } catch {
           // Ignore invalid request URL and continue fallback logic.
@@ -98,15 +127,21 @@ window.fetch = async (input: RequestInfo, init?: RequestInit) => {
     if (typeof input === 'string') {
       const value = input.trim()
       if (isAbsoluteUrl(value)) {
-        return shouldAttachApiCredentials(value)
-          ? originalFetch(value, withApiCredentials(init))
-          : originalFetch(value, init)
+        const requestUrl = new URL(value, window.location.origin)
+        if (!shouldAttachApiCredentials(value)) {
+          return originalFetch(value, init)
+        }
+        return fetchWithRefreshRetry(requestUrl, () =>
+          originalFetch(value, withApiCredentials(init))
+        )
       }
       const requestUrl = new URL(value, window.location.origin)
       if (isApiPath(requestUrl.pathname)) {
-        return originalFetch(
-          resolveBackendUrl(requestUrl.pathname + requestUrl.search),
-          withApiCredentials(init)
+        return fetchWithRefreshRetry(requestUrl, () =>
+          originalFetch(
+            resolveBackendUrl(requestUrl.pathname + requestUrl.search),
+            withApiCredentials(init)
+          )
         )
       }
       return originalFetch(value, init)
@@ -115,11 +150,13 @@ window.fetch = async (input: RequestInfo, init?: RequestInit) => {
     if (input instanceof Request) {
       const requestUrl = new URL(input.url, window.location.origin)
       if (requestUrl.origin === window.location.origin && isApiPath(requestUrl.pathname)) {
-        const rewrittenRequest = new Request(
-          resolveBackendUrl(requestUrl.pathname + requestUrl.search),
-          input
-        )
-        return originalFetch(rewrittenRequest, withApiCredentials(init))
+        return fetchWithRefreshRetry(requestUrl, () => {
+          const rewrittenRequest = new Request(
+            resolveBackendUrl(requestUrl.pathname + requestUrl.search),
+            input.clone()
+          )
+          return originalFetch(rewrittenRequest, withApiCredentials(init))
+        })
       }
     }
 

--- a/frontend/src/pages/AddAlarmPage.tsx
+++ b/frontend/src/pages/AddAlarmPage.tsx
@@ -10,6 +10,7 @@ import {
   LoaderCircle,
   Lock,
   ShieldCheck,
+  Sparkles,
   Smartphone,
 } from "lucide-react";
 import { flushSync } from "react-dom";
@@ -113,6 +114,12 @@ const hasDraftContent = (draft: AddAlarmDraft) =>
 const buildPlanStartResistanceLabel = (resistanceLevel?: number) => {
   if (resistanceLevel == null) return "시작 저항 보통";
   return resistanceLevel >= 7 ? "시작 저항 높음" : "시작 저항 보통";
+};
+
+const STUDIO_PRIVACY_LABELS: Record<PrivacyMode, string> = {
+  NORMAL: "Visible sync",
+  MASKED: "Masked sync",
+  APP_ONLY: "App-only private",
 };
 
 const StepPill: React.FC<{
@@ -277,6 +284,20 @@ const AddAlarmPage: React.FC<{ activeDate?: string }> = ({ activeDate }) => {
       (entry) => entry.startMinutes < endMinutes && entry.endMinutes > startMinutes
     );
   }, [selectedWindow, timelineEntries, wizard.state.alarm?.ends_next_day]);
+
+  const currentStepMeta = STEP_META.find((item) => item.step === wizard.step) ?? STEP_META[0];
+  const activePrivacyMode = wizard.state.privacy_mode ?? completedPrivacyMode;
+  const syncStatusLabel = googleLoading
+    ? "Syncing now"
+    : isConnected
+    ? "Google calendar live"
+    : "Private app-only timeline";
+  const launchWindowLabel = selectedWindow
+    ? `${selectedWindow.startLabel} - ${selectedWindow.endLabel}`
+    : wizard.state.alarm?.start_time || wizard.state.alarm?.time || "Window not locked";
+  const draftStatusLabel = draftSavedAt
+    ? `Protected ${formatDateTime(draftSavedAt)}`
+    : "No protected draft";
 
   const applyDraft = (draft: AddAlarmDraft) => {
     flushSync(() => {
@@ -584,47 +605,124 @@ const AddAlarmPage: React.FC<{ activeDate?: string }> = ({ activeDate }) => {
     <div className="min-h-screen bg-[radial-gradient(circle_at_top_right,_rgba(14,165,233,0.16),_transparent_26%),linear-gradient(180deg,_#f9fcff_0%,_#f4f9ff_44%,_#f8fafc_100%)] pb-28">
       <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
         <div className="grid gap-4 lg:grid-cols-[1.18fr_0.82fr]">
-          <Card className="rounded-[32px] border-slate-200 bg-white/90 p-6 backdrop-blur">
-            <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <Card className="overflow-hidden rounded-[36px] border-slate-200 bg-[linear-gradient(135deg,_rgba(14,165,233,0.12),_rgba(255,255,255,0.98)_38%,_rgba(15,23,42,0.04))] p-6 backdrop-blur">
+            <div className="grid gap-5 xl:grid-cols-[1.06fr_0.94fr] xl:items-end">
               <div className="space-y-4">
-                <span className="inline-flex items-center gap-2 rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold text-sky-700">
+                <span className="inline-flex items-center gap-2 rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-sky-700">
                   <BellPlus className="h-3.5 w-3.5" />
-                  Production Alarm Builder
+                  Alarm Studio
                 </span>
                 <div>
-                  <h1 className="text-3xl font-semibold tracking-tight text-slate-950">
-                    Add Alarm
+                  <h1 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-[2.3rem]">
+                    Design a launch-grade execution block
                   </h1>
                   <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
-                    작업, 미세 행동, 검증 미션, 동기화 정책을 분리해서 단계별로
-                    설정하는 실행 전용 페이지입니다.
+                    Alarm Studio is now a dedicated production flow. It turns intent into an
+                    executable block with timing, privacy mode, sync strategy, and mission logic
+                    tuned for real-world delivery.
                   </p>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-[28px] border border-white/70 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Blueprint
+                    </div>
+                    <div className="mt-2 text-sm font-semibold text-slate-950">
+                      Task, trigger, and mission stack
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Shape the block from action design down to resistance handling.
+                    </div>
+                  </div>
+                  <div className="rounded-[28px] border border-white/70 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Sync Policy
+                    </div>
+                    <div className="mt-2 text-sm font-semibold text-slate-950">
+                      {isConnected ? "Google calendar is live" : "App-only mode is ready"}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Choose between visible sync, masked sync, or app-only delivery.
+                    </div>
+                  </div>
+                  <div className="rounded-[28px] border border-white/70 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Launch State
+                    </div>
+                    <div className="mt-2 text-sm font-semibold text-slate-950">
+                      {draftSavedAt ? "Draft protected locally" : "Fresh studio session"}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Resume safely after interruption without losing timing or mission state.
+                    </div>
+                  </div>
                 </div>
               </div>
 
-              <div className="grid gap-3 sm:grid-cols-3">
-                <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-                  <div className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
-                    Sync
+              <div className="grid gap-3">
+                <div className="rounded-[32px] border border-slate-200/70 bg-[linear-gradient(180deg,_#020617_0%,_#111827_52%,_#0f172a_100%)] p-5 text-white shadow-[0_24px_60px_rgba(15,23,42,0.32)]">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-sky-200">
+                        Control Deck
+                      </div>
+                      <div className="mt-2 text-2xl font-semibold">Stage {wizard.step}</div>
+                      <div className="mt-1 text-sm text-slate-300">
+                        {currentStepMeta.label} · {currentStepMeta.summary}
+                      </div>
+                    </div>
+                    <div className="rounded-2xl bg-white/10 p-3">
+                      <Sparkles className="h-5 w-5 text-sky-200" />
+                    </div>
                   </div>
-                  <div className="mt-1 text-sm font-semibold text-slate-900">
-                    {isConnected ? "Google 연결됨" : "앱 전용 저장"}
+
+                  <div className="mt-5 grid gap-3 text-xs text-slate-300">
+                    <div className="rounded-2xl bg-white/5 px-3 py-3">
+                      <div className="text-[10px] uppercase tracking-[0.16em] text-slate-400">
+                        Sync Layer
+                      </div>
+                      <div className="mt-1 text-sm text-white">{syncStatusLabel}</div>
+                    </div>
+                    <div className="rounded-2xl bg-white/5 px-3 py-3">
+                      <div className="text-[10px] uppercase tracking-[0.16em] text-slate-400">
+                        Launch Window
+                      </div>
+                      <div className="mt-1 text-sm text-white">{launchWindowLabel}</div>
+                    </div>
+                    <div className="rounded-2xl bg-white/5 px-3 py-3">
+                      <div className="text-[10px] uppercase tracking-[0.16em] text-slate-400">
+                        Draft Guard
+                      </div>
+                      <div className="mt-1 text-sm text-white">{draftStatusLabel}</div>
+                    </div>
                   </div>
                 </div>
-                <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-                  <div className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
-                    Date
+
+                <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-3">
+                  <div className="rounded-[24px] border border-slate-200 bg-white/80 px-4 py-3 shadow-sm">
+                    <div className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
+                      Privacy
+                    </div>
+                    <div className="mt-1 text-sm font-semibold text-slate-900">
+                      {STUDIO_PRIVACY_LABELS[activePrivacyMode]}
+                    </div>
                   </div>
-                  <div className="mt-1 text-sm font-semibold text-slate-900">
-                    {wizard.state.date}
+                  <div className="rounded-[24px] border border-slate-200 bg-white/80 px-4 py-3 shadow-sm">
+                    <div className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
+                      Date
+                    </div>
+                    <div className="mt-1 text-sm font-semibold text-slate-900">
+                      {wizard.state.date}
+                    </div>
                   </div>
-                </div>
-                <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-                  <div className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
-                    Draft
-                  </div>
-                  <div className="mt-1 text-sm font-semibold text-slate-900">
-                    {draftSavedAt ? "자동 저장됨" : "초안 없음"}
+                  <div className="rounded-[24px] border border-slate-200 bg-white/80 px-4 py-3 shadow-sm">
+                    <div className="text-[11px] font-medium uppercase tracking-wide text-slate-400">
+                      Conflicts
+                    </div>
+                    <div className="mt-1 text-sm font-semibold text-slate-900">
+                      {scheduleConflicts.length > 0 ? `${scheduleConflicts.length} live` : "Clear"}
+                    </div>
                   </div>
                 </div>
               </div>
@@ -635,45 +733,47 @@ const AddAlarmPage: React.FC<{ activeDate?: string }> = ({ activeDate }) => {
             <button
               type="button"
               onClick={() => navigate("/my-page")}
-              className="rounded-[28px] border border-slate-200 bg-white/85 p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300"
+              className="group relative overflow-hidden rounded-[28px] border border-slate-200 bg-[linear-gradient(145deg,_rgba(255,255,255,0.96),_rgba(241,245,249,0.9))] p-5 text-left shadow-[0_16px_40px_rgba(15,23,42,0.08)] transition hover:-translate-y-1 hover:border-sky-300 hover:shadow-[0_24px_60px_rgba(14,165,233,0.16)]"
             >
+              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-sky-300 to-transparent opacity-70" />
               <div className="flex items-center justify-between">
-                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950 text-white shadow-lg shadow-slate-900/15 transition group-hover:scale-105">
                   <ShieldCheck className="h-5 w-5" />
                 </div>
-                <ArrowRight className="h-4 w-4 text-slate-400" />
+                <ArrowRight className="h-4 w-4 text-slate-400 transition group-hover:translate-x-1 group-hover:text-sky-600" />
               </div>
               <div className="mt-4 text-sm font-semibold text-slate-900">
-                마이페이지 가기
+                Open My Page
               </div>
               <div className="mt-1 text-xs leading-5 text-slate-500">
-                목표와 강점 정보를 먼저 정리하면 알람 제안 정확도가 더 좋아집니다.
+                Tighten identity, strengths, and constraints before finalizing this execution block.
               </div>
             </button>
 
             <button
               type="button"
               onClick={() => navigate("/signal-inbox")}
-              className="rounded-[28px] border border-slate-200 bg-white/85 p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300"
+              className="group relative overflow-hidden rounded-[28px] border border-slate-200 bg-[linear-gradient(145deg,_rgba(255,255,255,0.96),_rgba(241,245,249,0.9))] p-5 text-left shadow-[0_16px_40px_rgba(15,23,42,0.08)] transition hover:-translate-y-1 hover:border-sky-300 hover:shadow-[0_24px_60px_rgba(14,165,233,0.16)]"
             >
+              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-emerald-300 to-transparent opacity-70" />
               <div className="flex items-center justify-between">
-                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-600 text-white">
+                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-600 text-white shadow-lg shadow-emerald-900/10 transition group-hover:scale-105">
                   <CalendarDays className="h-5 w-5" />
                 </div>
-                <ArrowRight className="h-4 w-4 text-slate-400" />
+                <ArrowRight className="h-4 w-4 text-slate-400 transition group-hover:translate-x-1 group-hover:text-emerald-600" />
               </div>
               <div className="mt-4 text-sm font-semibold text-slate-900">
-                신호함에서 데이터 보기
+                Review Signal Inbox
               </div>
               <div className="mt-1 text-xs leading-5 text-slate-500">
-                저장한 신호, 반복 로그, 행동 질문을 한곳에서 확인할 수 있습니다.
+                Pull recent loops and signal data into the execution decision before launch.
               </div>
             </button>
 
             <button
               type="button"
               onClick={() =>
-                navigate(buildPlannerHref("deadline", { baseSearchParams: searchParams }), {
+                navigate(buildPlannerHref("today", { baseSearchParams: searchParams }), {
                   state: {
                     draftTitle: wizard.state.task?.task_title,
                     draftDate: wizard.state.date,
@@ -683,19 +783,20 @@ const AddAlarmPage: React.FC<{ activeDate?: string }> = ({ activeDate }) => {
                   },
                 })
               }
-              className="rounded-[28px] border border-slate-200 bg-white/85 p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300"
+              className="group relative overflow-hidden rounded-[28px] border border-slate-200 bg-[linear-gradient(145deg,_rgba(255,255,255,0.96),_rgba(241,245,249,0.9))] p-5 text-left shadow-[0_16px_40px_rgba(15,23,42,0.08)] transition hover:-translate-y-1 hover:border-sky-300 hover:shadow-[0_24px_60px_rgba(14,165,233,0.16)]"
             >
+              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-cyan-300 to-transparent opacity-70" />
               <div className="flex items-center justify-between">
-                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-sky-600 text-white">
+                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-sky-600 text-white shadow-lg shadow-sky-900/10 transition group-hover:scale-105">
                   <BellPlus className="h-5 w-5" />
                 </div>
-                <ArrowRight className="h-4 w-4 text-slate-400" />
+                <ArrowRight className="h-4 w-4 text-slate-400 transition group-hover:translate-x-1 group-hover:text-sky-600" />
               </div>
               <div className="mt-4 text-sm font-semibold text-slate-900">
-                마감 플랜 만들기
+                Open Planner Workspace
               </div>
               <div className="mt-1 text-xs leading-5 text-slate-500">
-                마감일과 가용 시간을 기준으로 오늘 체크리스트와 주간 계획을 함께 관리합니다.
+                Return to today and deadline operations with this block ready to deploy.
               </div>
             </button>
           </div>

--- a/frontend/src/pages/DeadlinePlannerPage.tsx
+++ b/frontend/src/pages/DeadlinePlannerPage.tsx
@@ -27,7 +27,7 @@ import {
   toChecklistEditorText,
 } from "../utils/deadlinePlanner";
 import { todayInKoreaIso } from "../utils/koreaTime";
-import { buildPlannerHref } from "../utils/plannerRoutes";
+import { buildAddAlarmHref } from "../utils/plannerRoutes";
 
 type PlannerLocationState = {
   draftTitle?: string;
@@ -104,7 +104,62 @@ const GoalCard: React.FC<{
     agenda.nextItems.length > 0;
 
   return (
-    <Card className="rounded-[28px] border-slate-200 p-5">
+    <Card className="overflow-hidden rounded-[32px] border-slate-200 bg-[linear-gradient(145deg,_rgba(255,255,255,0.98),_rgba(248,250,252,0.92))] p-6 shadow-[0_18px_45px_rgba(15,23,42,0.08)]">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <PlannerBadge label={summary.dDay >= 0 ? `D-${summary.dDay}` : `D+${Math.abs(summary.dDay)}`} />
+            <PlannerBadge label={`Completion ${summary.completionRate}%`} tone="emerald" />
+            {summary.driftMessage && <PlannerBadge label="Drift Risk" tone="amber" />}
+          </div>
+          <div>
+            <div className="text-xl font-semibold text-slate-950">{plan.title}</div>
+            <div className="mt-1 text-sm text-slate-500">
+              {plan.startDate} to {plan.deadlineDate} · {plan.windowStartTime} - {plan.windowEndTime}
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-[24px] bg-slate-950 px-4 py-3 text-white shadow-[0_18px_40px_rgba(15,23,42,0.2)]">
+              <div className="text-[11px] uppercase tracking-[0.14em] text-sky-200">Goal Egg</div>
+              <div className="mt-2 text-2xl font-semibold">{summary.hatchProbability}%</div>
+              <div className="mt-1 text-xs text-slate-300">{summary.hatchStage}</div>
+            </div>
+            <div className="rounded-[24px] border border-slate-200 bg-white/85 px-4 py-3 shadow-sm">
+              <div className="text-[11px] uppercase tracking-wide text-slate-400">Open Items</div>
+              <div className="mt-2 text-2xl font-semibold text-slate-900">{agenda.pendingItems.length}</div>
+            </div>
+            <div className="rounded-[24px] border border-slate-200 bg-white/85 px-4 py-3 shadow-sm">
+              <div className="text-[11px] uppercase tracking-wide text-slate-400">Completed</div>
+              <div className="mt-2 text-2xl font-semibold text-slate-900">
+                {summary.completedCount}/{summary.totalCount}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" onClick={() => onEdit(plan)}>
+            <span className="inline-flex items-center gap-2">
+              <Pencil className="h-4 w-4" />
+              Edit
+            </span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              void onDelete(plan.id);
+            }}
+          >
+            <span className="inline-flex items-center gap-2 text-rose-600">
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </span>
+          </Button>
+        </div>
+      </div>
+
+      <div className="hidden">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-3">
           <div className="flex flex-wrap items-center gap-2">
@@ -159,6 +214,75 @@ const GoalCard: React.FC<{
         </div>
       </div>
 
+      </div>
+
+      <div className="mt-5 space-y-3">
+        {agenda.pendingItems.length === 0 ? (
+          <div className="rounded-[24px] border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-sm text-slate-500">
+            Today's visible queue is clear.
+          </div>
+        ) : (
+          agenda.pendingItems.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => {
+                void onToggle(plan.id, item.id);
+              }}
+              className="flex w-full items-start gap-3 rounded-[24px] border border-slate-200 bg-white px-4 py-3 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300 hover:bg-sky-50"
+            >
+              <div
+                className={`mt-0.5 flex h-5 w-5 items-center justify-center rounded-full border ${
+                  item.lane === "overdue"
+                    ? "border-amber-400 bg-amber-50 text-amber-600"
+                    : "border-sky-300 bg-sky-50 text-sky-600"
+                }`}
+              >
+                <CheckCircle2 className="h-3.5 w-3.5" />
+              </div>
+              <div className="flex-1">
+                <div className="text-sm font-medium text-slate-900">{item.title}</div>
+                <div className="mt-1 text-xs text-slate-500">
+                  {item.estMinutes} min ·{" "}
+                  {item.lane === "overdue" ? "Recovered from backlog" : "Scheduled for today"}
+                </div>
+              </div>
+            </button>
+          ))
+        )}
+
+        {completedTodayItems.length > 0 && (
+          <div className="space-y-2">
+            <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              Completed Today
+            </div>
+            {completedTodayItems.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => {
+                  void onToggle(plan.id, item.id);
+                }}
+                className="flex w-full items-start gap-3 rounded-[24px] border border-emerald-200 bg-emerald-50 px-4 py-3 text-left transition hover:bg-emerald-100"
+              >
+                <div className="mt-0.5 flex h-5 w-5 items-center justify-center rounded-full border border-emerald-500 bg-emerald-500 text-white">
+                  <CheckCircle2 className="h-3.5 w-3.5" />
+                </div>
+                <div className="flex-1">
+                  <div className="text-sm font-medium text-emerald-900 line-through">
+                    {item.title}
+                  </div>
+                  <div className="mt-1 text-xs text-emerald-700">
+                    Tap again to return it to the live queue.
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="hidden">
       <div className="mt-5 space-y-3">
         {agenda.pendingItems.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-slate-200 bg-slate-50 px-4 py-5 text-sm text-slate-500">
@@ -224,6 +348,31 @@ const GoalCard: React.FC<{
         )}
       </div>
 
+      </div>
+
+      {hasPullForwardAction && (
+        <div className="mt-4 rounded-[24px] border border-emerald-200 bg-emerald-50 px-4 py-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <div className="text-sm font-semibold text-emerald-900">Reserve capacity detected.</div>
+              <div className="mt-1 text-xs text-emerald-700">
+                Pull {agenda.nextItems.length} future items into today while space is still open.
+              </div>
+            </div>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={() => {
+                void onPullForward(plan.id);
+              }}
+            >
+              Pull Forward
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <div className="hidden">
       {hasPullForwardAction && (
         <div className="mt-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -245,6 +394,7 @@ const GoalCard: React.FC<{
           </div>
         </div>
       )}
+      </div>
     </Card>
   );
 };
@@ -393,7 +543,102 @@ const DeadlinePlannerPage: React.FC<{ activeDate?: string }> = ({
     <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.18),_transparent_30%),linear-gradient(180deg,_#f6fbff_0%,_#eef6ff_42%,_#f8fafc_100%)] pb-28">
       <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
         <div className="grid gap-4 lg:grid-cols-[1.18fr_0.82fr]">
-          <Card className="rounded-[32px] border-slate-200 bg-white/90 p-6 backdrop-blur">
+          <Card className="overflow-hidden rounded-[36px] border-slate-200 bg-[linear-gradient(135deg,_rgba(56,189,248,0.14),_rgba(255,255,255,0.98)_36%,_rgba(16,185,129,0.08))] p-6 shadow-[0_20px_60px_rgba(15,23,42,0.08)] backdrop-blur">
+            <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+              <div className="space-y-4">
+                <span className="inline-flex items-center gap-2 rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-sky-700">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  Deadline Engine
+                </span>
+                <div>
+                  <h1 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-[2.25rem]">
+                    Run deadline programs like a production system
+                  </h1>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                    This workspace breaks a large outcome into visible daily load, protects time
+                    windows, and keeps drift under control. It is the long-range control room
+                    behind the faster execution flows.
+                  </p>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-[28px] border border-white/70 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Goal Volume
+                    </div>
+                    <div className="mt-2 text-2xl font-semibold text-slate-950">{plans.length}</div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Active deadline programs currently in flight.
+                    </div>
+                  </div>
+                  <div className="rounded-[28px] border border-white/70 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Drift Alerts
+                    </div>
+                    <div className="mt-2 text-2xl font-semibold text-slate-950">
+                      {summaries.filter((item) => item.driftMessage).length}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Plans that need intervention before they slip.
+                    </div>
+                  </div>
+                  <div className="rounded-[28px] border border-white/70 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Finished
+                    </div>
+                    <div className="mt-2 text-2xl font-semibold text-slate-950">
+                      {summaries.filter((item) => item.completionRate >= 100).length}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Programs that already crossed the line.
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-[32px] border border-slate-200/70 bg-[linear-gradient(180deg,_#020617_0%,_#111827_52%,_#0f172a_100%)] p-5 text-white shadow-[0_24px_60px_rgba(15,23,42,0.32)]">
+                <div className="text-xs font-medium uppercase tracking-[0.18em] text-sky-200">
+                  Deadline Snapshot
+                </div>
+                <div className="mt-3 text-3xl font-semibold">
+                  {summaries.length > 0
+                    ? `${Math.round(
+                        summaries.reduce((sum, item) => sum + item.hatchProbability, 0) /
+                          summaries.length
+                      )}%`
+                    : "0%"}
+                </div>
+                <div className="mt-2 text-sm text-slate-300">
+                  Average hatch probability across active programs.
+                </div>
+                <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+                  <div className="rounded-2xl bg-white/5 px-4 py-3">
+                    <div className="text-[10px] uppercase tracking-[0.16em] text-slate-400">
+                      Focus Date
+                    </div>
+                    <div className="mt-1 text-sm text-white">{activeDate}</div>
+                  </div>
+                  <div className="rounded-2xl bg-white/5 px-4 py-3">
+                    <div className="text-[10px] uppercase tracking-[0.16em] text-slate-400">
+                      Notifications
+                    </div>
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        await requestNotificationPermission();
+                        setSaveNotice("Notification permission check completed.");
+                      }}
+                      className="mt-2 inline-flex items-center gap-2 rounded-2xl bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/15"
+                    >
+                      <BellRing className="h-4 w-4" />
+                      Check Permission
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Card>
+          <Card className="hidden rounded-[32px] border-slate-200 bg-white/90 p-6 backdrop-blur">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
               <div className="space-y-4">
                 <span className="inline-flex items-center gap-2 rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold text-sky-700">
@@ -446,9 +691,37 @@ const DeadlinePlannerPage: React.FC<{ activeDate?: string }> = ({
             <button
               type="button"
               onClick={() =>
-                navigate(buildPlannerHref("alarm", { baseSearchParams: searchParams }))
+                navigate(
+                  buildAddAlarmHref({
+                    baseSearchParams: searchParams,
+                    activeDate,
+                  })
+                )
               }
-              className="rounded-[28px] border border-slate-200 bg-white/85 p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300"
+              className="rounded-[28px] border border-slate-200 bg-[linear-gradient(145deg,_rgba(255,255,255,0.96),_rgba(241,245,249,0.92))] p-5 text-left shadow-[0_16px_40px_rgba(15,23,42,0.08)] transition hover:-translate-y-1 hover:border-sky-300 hover:shadow-[0_24px_60px_rgba(14,165,233,0.16)]"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                  <AlarmClockCheck className="h-5 w-5" />
+                </div>
+                <ArrowRight className="h-4 w-4 text-slate-400" />
+              </div>
+              <div className="mt-4 text-sm font-semibold text-slate-900">Open Alarm Studio</div>
+              <div className="mt-1 text-xs leading-5 text-slate-500">
+                Build execution alarms and sync policy in the dedicated studio flow.
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                navigate(
+                  buildAddAlarmHref({
+                    baseSearchParams: searchParams,
+                    activeDate,
+                  })
+                )
+              }
+              className="hidden rounded-[28px] border border-slate-200 bg-white/85 p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300"
             >
               <div className="flex items-center justify-between">
                 <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950 text-white">

--- a/frontend/src/pages/InstallGuidePage.tsx
+++ b/frontend/src/pages/InstallGuidePage.tsx
@@ -1,58 +1,36 @@
+import { useMemo } from "react";
+import { QRCodeCanvas } from "qrcode.react";
 import { Link } from "react-router-dom";
+
 import AlarmInstallGuide from "../components/feature/AlarmInstallGuide";
-import { buildApkDownloadUrl } from "../utils/apkDownload";
-
-const getAppInstallUrl = () => {
-  if (typeof window === "undefined") {
-    return "";
-  }
-
-  const raw =
-    import.meta.env.VITE_APP_INSTALL_URL ||
-    import.meta.env.VITE_DIRECT_APK_URL ||
-    `${window.location.origin}/latest.apk`;
-  return buildApkDownloadUrl(raw);
-};
-
-const playStoreUrl = import.meta.env.VITE_PLAY_STORE_URL || "";
-const directApkUrl = import.meta.env.VITE_DIRECT_APK_URL || "";
-const internalTestQrUrl = import.meta.env.VITE_INTERNAL_TEST_QR_URL || "";
-
-const isApkLikeUrl = (url: string): boolean => {
-  const normalized = url.toLowerCase();
-  return normalized.includes(".apk") || normalized.includes("/latest.apk");
-};
-
-const resolveInternalTestQrUrl = (fallbackInstallUrl: string): string => {
-  if (!internalTestQrUrl) {
-    return fallbackInstallUrl;
-  }
-
-  const resolved = buildApkDownloadUrl(internalTestQrUrl);
-  if (!isApkLikeUrl(resolved)) {
-    return fallbackInstallUrl;
-  }
-
-  return resolved;
-};
-
-const getQrImage = (url: string) =>
-  `https://api.qrserver.com/v1/create-qr-code/?size=180x180&margin=1&data=${encodeURIComponent(url)}`;
+import { useInstallBootstrap } from "../hooks/useInstallBootstrap";
+import {
+  getFallbackInstallBootstrap,
+  getInstallChannelLabel,
+  getInstallPrimaryLabel,
+} from "../utils/installBootstrap";
 
 const SectionTitle = ({ title }: { title: string }) => (
   <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
 );
 
 const InstallGuidePage = () => {
-  const appInstallUrl = getAppInstallUrl();
-  const fallbackApkUrl = buildApkDownloadUrl(
-    directApkUrl || (typeof window !== "undefined" ? `${window.location.origin}/latest.apk` : "")
-  );
-  const qrApkUrl = resolveInternalTestQrUrl(appInstallUrl);
+  const { bootstrap, loading, warning } = useInstallBootstrap();
+  const fallbackBootstrap = useMemo(() => getFallbackInstallBootstrap(), []);
+  const currentBootstrap = loading ? fallbackBootstrap : bootstrap;
+  const primaryInstallUrl =
+    currentBootstrap.installUrl || currentBootstrap.fallbackUrl;
+  const fallbackInstallUrl =
+    currentBootstrap.fallbackUrl || currentBootstrap.installUrl;
+  const qrValue = currentBootstrap.qrPayload || primaryInstallUrl;
+  const playStoreUrl =
+    currentBootstrap.channel === "play_store"
+      ? currentBootstrap.installUrl
+      : (import.meta.env.VITE_PLAY_STORE_URL || "").trim();
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <div className="max-w-2xl mx-auto px-4 py-6">
+      <div className="mx-auto max-w-2xl px-4 py-6">
         <div className="mb-4 text-sm text-gray-500">
           <Link to="/" className="text-indigo-600 hover:underline">
             홈으로
@@ -61,91 +39,121 @@ const InstallGuidePage = () => {
 
         <h1 className="text-2xl font-bold text-gray-900">앱 설치 안내</h1>
         <p className="mt-2 text-sm text-gray-600">
-          안드로이드 APK 또는 Play Store에서 앱을 받아 설치하는 방법입니다. 아래 링크와 QR 코드를 통해
-          최신 설치 파일을 내려받아 주세요.
+          안드로이드 앱 설치 경로와 QR 정보를 한곳에서 확인할 수 있습니다.
+          최신 설치 메타데이터가 있으면 우선 사용하고, 없으면 안전한 기본 경로로
+          안내합니다.
         </p>
 
         <div className="mt-5">
           <AlarmInstallGuide
-            title="직접 테스트를 위한 알림 앱 설치"
-            description="현재 사용 중인 설치 URL을 기준으로, 기기에서 APK 또는 QR 복구를 진행할 수 있습니다."
-            installUrl={appInstallUrl}
+            title="알람 전달용 앱 설치"
+            description="브라우저보다 앱 환경에서 알람 전달이 더 안정적입니다. 아래 링크나 QR을 사용해 설치를 이어가세요."
+            bootstrap={currentBootstrap}
+            loading={loading}
+            warning={warning}
             className="bg-white"
           />
         </div>
 
         <section className="mt-6 rounded-lg border border-gray-200 bg-white p-4">
-          <SectionTitle title="플레이 스토어 설치" />
-          {playStoreUrl ? (
+          <SectionTitle title="현재 배포 정보" />
+          <div className="mt-3 space-y-2 text-sm text-gray-700">
+            <p>
+              채널:{" "}
+              <span className="font-medium">
+                {getInstallChannelLabel(currentBootstrap.channel)}
+              </span>
+            </p>
+            <p>
+              기본 링크:{" "}
+              <code className="break-all">{primaryInstallUrl || "(없음)"}</code>
+            </p>
+            <p>
+              메타데이터 소스:{" "}
+              <span className="font-medium">
+                {currentBootstrap.source === "manifest" ? "manifest" : "fallback"}
+              </span>
+            </p>
+            {currentBootstrap.versionName && (
+              <p>버전: {currentBootstrap.versionName}</p>
+            )}
+            {currentBootstrap.buildId && <p>빌드 ID: {currentBootstrap.buildId}</p>}
+            {currentBootstrap.releaseNotes && (
+              <p className="leading-6">릴리스 노트: {currentBootstrap.releaseNotes}</p>
+            )}
+          </div>
+        </section>
+
+        <section className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
+          <SectionTitle title="기본 설치 경로" />
+          {primaryInstallUrl ? (
             <a
-              href={playStoreUrl}
+              href={primaryInstallUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="mt-3 inline-flex rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700"
             >
-              Play Store에서 설치하기
+              {getInstallPrimaryLabel(currentBootstrap.channel)}
             </a>
           ) : (
-            <p className="mt-3 text-sm text-gray-600">현재 Play Store 링크가 설정되어 있지 않습니다.</p>
+            <p className="mt-3 text-sm text-gray-600">
+              현재 설치 링크가 비어 있습니다.
+            </p>
+          )}
+          {playStoreUrl && playStoreUrl !== primaryInstallUrl && (
+            <a
+              href={playStoreUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-2 mt-3 inline-flex rounded border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-100"
+            >
+              Play Store 열기
+            </a>
           )}
         </section>
 
         <section className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-          <SectionTitle title="대체 APK QR 다운로드" />
+          <SectionTitle title="QR 설치 경로" />
           <p className="mt-3 break-all text-xs text-gray-600">
-            현재 QR 대상 URL: <code>{qrApkUrl || "(없음)"}</code>
+            현재 QR 대상: <code>{qrValue || "(없음)"}</code>
           </p>
-          {qrApkUrl ? (
+          {qrValue ? (
             <div className="mt-3 space-y-3">
-              <p className="text-sm text-gray-700">APK 링크가 유효한 경우 QR로도 바로 설치할 수 있습니다.</p>
               <a
-                href={qrApkUrl}
+                href={qrValue}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex rounded border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 hover:bg-gray-100"
               >
-                APK QR 링크 열기
+                QR 대상 열기
               </a>
-              <div>
-                <img
-                  src={getQrImage(qrApkUrl)}
-                  alt="APK QR"
-                  className="h-44 w-44 rounded border bg-white"
-                />
+              <div className="inline-flex rounded border bg-white p-3">
+                <QRCodeCanvas value={qrValue} size={180} level="M" includeMargin />
               </div>
             </div>
           ) : (
-            <p className="mt-3 text-sm text-gray-600">현재 APK QR 링크가 설정되어 있지 않습니다.</p>
+            <p className="mt-3 text-sm text-gray-600">
+              QR 대상 링크가 아직 준비되지 않았습니다.
+            </p>
           )}
         </section>
 
         <section className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-          <SectionTitle title="폴백 다운로드 APK" />
-          <p className="mt-3 text-sm text-gray-700">
-            Play Store 접속이 어려운 경우 아래 APK로 직접 받아 설치할 수 있습니다.
-          </p>
-          {fallbackApkUrl ? (
+          <SectionTitle title="대체 설치 경로" />
+          {fallbackInstallUrl ? (
             <a
-              href={fallbackApkUrl}
+              href={fallbackInstallUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="mt-3 inline-flex rounded bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-black"
             >
-              APK 직접 다운로드
+              대체 설치 링크 열기
             </a>
           ) : (
-            <p className="mt-3 text-sm text-gray-600">현재 APK 링크가 설정되어 있지 않습니다.</p>
+            <p className="mt-3 text-sm text-gray-600">
+              대체 설치 경로가 준비되지 않았습니다.
+            </p>
           )}
-        </section>
-
-        <section className="mt-4 rounded-lg border border-gray-200 bg-white p-4">
-          <SectionTitle title="안내" />
-          <ul className="mt-3 space-y-2 text-sm text-gray-700 list-disc list-inside">
-            <li>iOS: Safari에서는 앱 설치가 지원되지 않습니다.</li>
-            <li>Android: Chrome 또는 기본 브라우저에서 링크를 열어주세요.</li>
-            <li>설치가 완료되면 안내 메시지를 따라 앱을 실행하세요.</li>
-            <li>설치 실패가 반복되면 QR 이미지 파일을 새로고침해 다시 시도해 주세요.</li>
-          </ul>
         </section>
       </div>
     </div>

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -3,10 +3,10 @@ import {
   AlertCircle,
   ArrowRight,
   BellPlus,
+  CalendarClock,
   CheckCircle2,
   Egg,
   Inbox,
-  LayoutDashboard,
   LoaderCircle,
   LogOut,
   RefreshCw,
@@ -27,6 +27,7 @@ import {
   saveProfileBundle,
 } from "../services/profileService";
 import type { CapabilityProfilePayload, AspirationProfilePayload } from "../types/proposalOS";
+import { buildPlannerHref } from "../utils/plannerRoutes";
 import {
   buildProfileCompletion,
   buildProfileReadiness,
@@ -82,6 +83,7 @@ const clearDraft = (userId: string) => {
 };
 
 const formatDateTime = (value?: string | null) => {
+  if (!value) return "None";
   if (!value) return "없음";
   try {
     return new Intl.DateTimeFormat("ko-KR", {
@@ -190,18 +192,19 @@ const QuickActionCard: React.FC<{
   <button
     type="button"
     onClick={onClick}
-    className="flex w-full items-start justify-between rounded-3xl border border-slate-200 bg-white/80 p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300 hover:shadow-md"
+    className="group relative flex w-full items-start justify-between overflow-hidden rounded-[30px] border border-slate-200 bg-[linear-gradient(145deg,_rgba(255,255,255,0.96),_rgba(241,245,249,0.9))] p-5 text-left shadow-[0_16px_40px_rgba(15,23,42,0.08)] transition hover:-translate-y-1 hover:border-sky-300 hover:shadow-[0_24px_60px_rgba(14,165,233,0.16)]"
   >
-    <div className="space-y-2">
-      <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-slate-900 text-white">
+    <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-sky-300 to-transparent opacity-70" />
+    <div className="space-y-3">
+      <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950 text-white shadow-lg shadow-slate-900/15 transition group-hover:scale-105">
         {icon}
       </div>
       <div>
-        <div className="text-sm font-semibold text-slate-900">{title}</div>
+        <div className="text-sm font-semibold tracking-[0.01em] text-slate-950">{title}</div>
         <div className="mt-1 text-xs leading-5 text-slate-500">{description}</div>
       </div>
     </div>
-    <ArrowRight className="mt-1 h-4 w-4 text-slate-400" />
+    <ArrowRight className="mt-1 h-4 w-4 text-slate-400 transition group-hover:translate-x-1 group-hover:text-sky-600" />
   </button>
 );
 
@@ -438,7 +441,167 @@ const MyPage: React.FC = () => {
     <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(14,165,233,0.18),_transparent_32%),linear-gradient(180deg,_#f8fbff_0%,_#eef5ff_45%,_#f8fafc_100%)] pb-28">
       <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
         <div className="grid gap-4 lg:grid-cols-[1.25fr_0.95fr]">
-          <Card className="rounded-[32px] border-slate-200 bg-white/85 p-6 backdrop-blur">
+          <Card className="overflow-hidden rounded-[36px] border-slate-200 bg-[linear-gradient(135deg,_rgba(14,165,233,0.12),_rgba(255,255,255,0.98)_38%,_rgba(16,185,129,0.08))] p-6 shadow-[0_20px_60px_rgba(15,23,42,0.08)] backdrop-blur">
+            <div className="grid gap-6 xl:grid-cols-[1.12fr_0.88fr]">
+              <div className="space-y-4">
+                <span className="inline-flex items-center gap-2 rounded-full bg-sky-100/90 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-sky-700">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  Profile OS
+                </span>
+                <div>
+                  <h1 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-[2.3rem]">
+                    Build the profile that drives every execution decision
+                  </h1>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                    This page now behaves like a personal operating system. Identity, strengths,
+                    constraints, and execution evidence are shaped here first, then reused by
+                    Alarm Studio, planning, and recommendation flows across the app.
+                  </p>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="rounded-[28px] border border-white/70 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Identity
+                    </div>
+                    <div className="mt-2 text-sm font-semibold text-slate-950">
+                      {readiness.identity ? "Ready for strategic use" : "Needs sharper direction"}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Aspiration, target role, and north star framing.
+                    </div>
+                  </div>
+                  <div className="rounded-[28px] border border-white/70 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Plan Layer
+                    </div>
+                    <div className="mt-2 text-sm font-semibold text-slate-950">
+                      {readiness.plan ? "Roadmap is structured" : "Roadmap needs shaping"}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Values, constraints, and 90-day direction.
+                    </div>
+                  </div>
+                  <div className="rounded-[28px] border border-white/70 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Execution
+                    </div>
+                    <div className="mt-2 text-sm font-semibold text-slate-950">
+                      {readiness.execution ? "Signals are usable" : "Signals are still thin"}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Strengths, tools, and proof of delivery.
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <StatusChip
+                    label={readiness.identity ? "Identity ready" : "Identity needs work"}
+                    tone={readiness.identity ? "ready" : "pending"}
+                  />
+                  <StatusChip
+                    label={readiness.plan ? "Plan layer ready" : "Plan layer needs work"}
+                    tone={readiness.plan ? "ready" : "pending"}
+                  />
+                  <StatusChip
+                    label={readiness.execution ? "Execution signals ready" : "Execution needs work"}
+                    tone={readiness.execution ? "ready" : "pending"}
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4">
+                <div className="rounded-[32px] border border-slate-200/70 bg-[linear-gradient(180deg,_#020617_0%,_#111827_52%,_#0f172a_100%)] p-5 text-white shadow-[0_24px_60px_rgba(15,23,42,0.32)]">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="text-xs font-medium uppercase tracking-[0.18em] text-sky-200">
+                        Profile Readiness
+                      </div>
+                      <div className="mt-2 text-4xl font-semibold">{completion}%</div>
+                    </div>
+                    <div className="rounded-2xl bg-white/10 p-3">
+                      <Target className="h-5 w-5 text-sky-200" />
+                    </div>
+                  </div>
+                  <div className="mt-4 h-2 overflow-hidden rounded-full bg-white/10">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-sky-400 via-cyan-300 to-emerald-300"
+                      style={{ width: `${completion}%` }}
+                    />
+                  </div>
+                  <div className="mt-5 grid gap-3 text-xs text-slate-300">
+                    <div className="rounded-2xl bg-white/5 px-3 py-3">
+                      <div className="text-[10px] uppercase tracking-[0.16em] text-slate-400">
+                        Last Publish
+                      </div>
+                      <div className="mt-1 text-sm text-white">{formatDateTime(lastSavedAt)}</div>
+                    </div>
+                    <div className="rounded-2xl bg-white/5 px-3 py-3">
+                      <div className="text-[10px] uppercase tracking-[0.16em] text-slate-400">
+                        Local Draft
+                      </div>
+                      <div className="mt-1 text-sm text-white">{formatDateTime(draftSavedAt)}</div>
+                    </div>
+                    <div className="rounded-2xl bg-white/5 px-3 py-3">
+                      <div className="text-[10px] uppercase tracking-[0.16em] text-slate-400">
+                        Account
+                      </div>
+                      <div className="mt-1 break-all text-sm text-white">{user.email || user.uid}</div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-[28px] border border-slate-200 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Active Goals
+                    </div>
+                    <div className="mt-2 text-2xl font-semibold text-slate-950">
+                      {topGoalSummaries.length}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Live deadline programs currently influencing execution.
+                    </div>
+                  </div>
+                  <div className="rounded-[28px] border border-slate-200 bg-white/85 px-4 py-4 shadow-sm">
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      Sync State
+                    </div>
+                    <div className="mt-2 text-sm font-semibold text-slate-950">
+                      {hasUnsavedChanges ? "Profile changed locally" : "Profile synced to source"}
+                    </div>
+                    <div className="mt-1 text-xs leading-5 text-slate-500">
+                      Keep this layer clean before you generate alarms or recommendations.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </Card>
+
+          <div className="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
+            <QuickActionCard
+              icon={<BellPlus className="h-5 w-5" />}
+              title="Open Alarm Studio"
+              description="Turn this profile into a precise execution alarm with sync and privacy rules."
+              onClick={() => navigate("/add-alarm")}
+            />
+            <QuickActionCard
+              icon={<Inbox className="h-5 w-5" />}
+              title="Review Signal Inbox"
+              description="Inspect recent loops and pressure signals before choosing the next move."
+              onClick={() => navigate("/signal-inbox")}
+            />
+            <QuickActionCard
+              icon={<CalendarClock className="h-5 w-5" />}
+              title="Open Planner Workspace"
+              description="Move into the live execution board once your profile layer is ready to drive decisions."
+              onClick={() => navigate(buildPlannerHref("today"))}
+            />
+          </div>
+
+          <Card className="hidden rounded-[32px] border-slate-200 bg-white/85 p-6 backdrop-blur">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
               <div className="space-y-4">
                 <span className="inline-flex items-center gap-2 rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold text-sky-700">
@@ -498,7 +661,7 @@ const MyPage: React.FC = () => {
             </div>
           </Card>
 
-          <div className="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
+          <div className="hidden grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
             <QuickActionCard
               icon={<BellPlus className="h-5 w-5" />}
               title="알람 만들기"

--- a/frontend/src/pages/PlanDayPage.tsx
+++ b/frontend/src/pages/PlanDayPage.tsx
@@ -25,6 +25,7 @@ import {
   parseKoreaTimeValue,
 } from "../utils/koreaTime";
 import type { PlannerWorkspaceResponse } from "../services/plannerWorkspaceService";
+import { PLANNER_CLIENT_STATE_CHANGED_EVENT } from "../services/plannerClientStateService";
 import {
   type AppOnlyEvent,
   buildPrivacyKey,
@@ -232,6 +233,29 @@ const PlanDayPage: React.FC<{
   useEffect(() => {
     void refreshAppOnlyEvents();
   }, [refreshAppOnlyEvents]);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const handlePlannerStateChanged = (event: Event) => {
+      const detail = (event as CustomEvent<{ userId?: string }>).detail;
+      if (!detail?.userId || detail.userId !== userId) {
+        return;
+      }
+      void refreshAppOnlyEvents();
+    };
+
+    window.addEventListener(
+      PLANNER_CLIENT_STATE_CHANGED_EVENT,
+      handlePlannerStateChanged as EventListener
+    );
+    return () => {
+      window.removeEventListener(
+        PLANNER_CLIENT_STATE_CHANGED_EVENT,
+        handlePlannerStateChanged as EventListener
+      );
+    };
+  }, [refreshAppOnlyEvents, userId]);
 
   useEffect(() => {
     if (wizard.state.step === 1) {

--- a/frontend/src/pages/PlanDayPage.tsx
+++ b/frontend/src/pages/PlanDayPage.tsx
@@ -17,7 +17,7 @@ import PlanSummary from "../components/plan/PlanSummary";
 import { TimeTable } from "../components/schedule/TimeTable";
 import type { ScheduleItem } from "../components/schedule/TimeTable";
 import AlarmInstallGuide from "../components/feature/AlarmInstallGuide";
-import { buildApkDownloadUrl } from "../utils/apkDownload";
+import { getFallbackInstallBootstrap } from "../utils/installBootstrap";
 import {
   addMinutesToKoreaOffsetDateTime,
   buildKoreaOffsetDateTime,
@@ -173,19 +173,8 @@ const PlanDayPage: React.FC<{
   const [bannerPatchResult, setBannerPatchResult] = useState<string | null>(null);
   const [showEmotionPrompt, setShowEmotionPrompt] = useState(false);
   const [showAlarmInstallGuide, setShowAlarmInstallGuide] = useState(false);
-  const directApkSource = (
-    import.meta.env.VITE_APP_INSTALL_URL ??
-    import.meta.env.VITE_DIRECT_APK_URL ??
-    (typeof window !== "undefined"
-      ? `${window.location.origin.replace(/\/+$/, "")}/latest.apk`
-      : "")
-  ).trim();
-  const normalizedDirectApkUrl = !directApkSource
-    ? ""
-    : /(?:\/latest\.apk(?:$|\?)|\.apk(?:$|\?))/i.test(directApkSource)
-      ? directApkSource
-      : `${directApkSource.replace(/\/+$/, "")}/latest.apk`;
-  const appInstallUrl = buildApkDownloadUrl(normalizedDirectApkUrl);
+  const installBootstrap = useMemo(() => getFallbackInstallBootstrap(), []);
+  const appInstallUrl = installBootstrap.installUrl || installBootstrap.fallbackUrl;
 
   const buildPlanStartResistanceLabel = (resistanceLevel?: number) => {
     if (resistanceLevel == null) return "시작 저항";

--- a/frontend/src/pages/PlannerPage.tsx
+++ b/frontend/src/pages/PlannerPage.tsx
@@ -1,8 +1,15 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, ArrowRight, CalendarClock, Clock3, Crosshair, ListTodo } from "lucide-react";
-import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import {
+  AlertTriangle,
+  ArrowRight,
+  BellPlus,
+  CalendarClock,
+  Crosshair,
+  ListTodo,
+  UserRound,
+} from "lucide-react";
+import { Navigate, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
-import AddAlarmPage from "./AddAlarmPage";
 import DeadlinePlannerPage from "./DeadlinePlannerPage";
 import PlanDayPage from "./PlanDayPage";
 import {
@@ -14,6 +21,7 @@ import {
   type PlannerWorkspaceResponse,
 } from "../services/plannerWorkspaceService";
 import {
+  buildAddAlarmHref,
   buildPlannerHref,
   normalizePlannerActiveDate,
   normalizePlannerTab,
@@ -21,28 +29,22 @@ import {
 } from "../utils/plannerRoutes";
 
 const TABS: Array<{
-  id: PlannerTab;
+  id: Exclude<PlannerTab, "alarm">;
   label: string;
   description: string;
   icon: React.ComponentType<{ className?: string }>;
 }> = [
   {
-    id: "deadline",
-    label: "마감",
-    description: "마감 목표를 만들고 목표를 쪼개서 오늘 분량까지 이어서 관리합니다.",
-    icon: ListTodo,
-  },
-  {
     id: "today",
-    label: "오늘",
-    description: "오늘 배정과 실행 흐름을 같은 planner 안에서 조정합니다.",
+    label: "Today",
+    description: "Run the live daily execution board in one focused workspace.",
     icon: CalendarClock,
   },
   {
-    id: "alarm",
-    label: "알람",
-    description: "오늘 일정과 연결된 알람 정책을 한 화면에서 맞춥니다.",
-    icon: Clock3,
+    id: "deadline",
+    label: "Deadline",
+    description: "Break down long goals and keep delivery windows under control.",
+    icon: ListTodo,
   },
 ];
 
@@ -114,7 +116,7 @@ const PlannerPage: React.FC = () => {
     };
   }, [activeDate]);
 
-  const handleTabChange = (nextTab: PlannerTab) => {
+  const handleTabChange = (nextTab: Exclude<PlannerTab, "alarm">) => {
     if (nextTab === activeTab) return;
     navigate(
       buildPlannerHref(nextTab, {
@@ -130,15 +132,15 @@ const PlannerPage: React.FC = () => {
   const snapshotCards = useMemo(
     () => [
       {
-        label: "Goal items",
+        label: "Goal Items",
         value: workspace?.goal_items.length ?? 0,
       },
       {
-        label: "Today assignments",
+        label: "Today Assignments",
         value: workspace?.daily_assignments.length ?? 0,
       },
       {
-        label: "Alarm policies",
+        label: "Alarm Policies",
         value: workspace?.alarm_policies.length ?? 0,
       },
       {
@@ -176,8 +178,7 @@ const PlannerPage: React.FC = () => {
     return {
       taskUid: focusedTaskUid,
       title: assignment?.title || goalItem?.title || "Planner item",
-      plannedMinutes:
-        assignment?.planned_minutes ?? goalItem?.est_minutes ?? null,
+      plannedMinutes: assignment?.planned_minutes ?? goalItem?.est_minutes ?? null,
       status:
         executionState?.status ||
         assignment?.status ||
@@ -209,42 +210,101 @@ const PlannerPage: React.FC = () => {
   const hasMissingFocusedTask =
     Boolean(focusedTaskUid) && !workspaceLoading && !workspaceError && !focusMatch;
 
-  const renderActiveTab = () => {
-    if (activeTab === "deadline") return <DeadlinePlannerPage activeDate={activeDate} />;
-    if (activeTab === "today") {
-      return (
-        <PlanDayPage
-          activeDate={activeDate}
-          workspace={workspace}
-          focusedTaskUid={focusedTaskUid}
-          workspaceLoading={workspaceLoading}
-          workspaceError={workspaceError}
-        />
-      );
-    }
-    return <AddAlarmPage activeDate={activeDate} />;
-  };
+  if (activeTab === "alarm") {
+    return (
+      <Navigate
+        to={buildAddAlarmHref({
+          baseSearchParams: searchParams,
+          activeDate,
+        })}
+        replace
+        state={location.state}
+      />
+    );
+  }
 
   return (
     <div className="space-y-4">
       <section className="mx-auto max-w-6xl px-4 pt-6 sm:px-6">
-        <div className="rounded-[32px] border border-slate-200 bg-white/95 p-5 shadow-sm sm:p-6">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="rounded-[36px] border border-slate-200 bg-[linear-gradient(135deg,_rgba(14,165,233,0.12),_rgba(255,255,255,0.98)_42%,_rgba(16,185,129,0.10))] p-5 shadow-sm sm:p-6">
+          <div className="grid gap-4 lg:grid-cols-[1.12fr_0.88fr]">
             <div>
-              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-sky-600">
-                Planner
+              <div className="inline-flex items-center rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-sky-700">
+                Planner Workspace
               </div>
-              <h1 className="mt-2 text-2xl font-semibold text-slate-950">
-                마감, 오늘, 알람을 하나의 planner 워크스페이스로 엽니다.
+              <h1 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950 sm:text-3xl">
+                The operating room for daily execution and deadline control
               </h1>
-              <p className="mt-2 text-sm leading-6 text-slate-500">
-                기존 분리 페이지는 유지하되, 메인 진입점은 `/planner` 하나로 묶었습니다.
-                웹과 앱이 같은 planner 데이터 축으로 수렴할 수 있도록 snapshot 상태도 함께 노출합니다.
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+                Planner now owns the live board for today and the deadline system for long-range
+                delivery. Alarm creation has been pulled into a dedicated Alarm Studio so each
+                screen does one job at production quality.
               </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm">
+                  Today + Deadline only
+                </span>
+                <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm">
+                  Alarm Studio separated
+                </span>
+                <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm">
+                  Shared Workspace Snapshot
+                </span>
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() =>
+                  navigate(
+                    buildAddAlarmHref({
+                      baseSearchParams: searchParams,
+                      activeDate,
+                    }),
+                    {
+                      state: location.state,
+                    }
+                  )
+                }
+                className="rounded-[28px] border border-slate-200 bg-white/90 p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                    <BellPlus className="h-5 w-5" />
+                  </div>
+                  <ArrowRight className="h-4 w-4 text-slate-400" />
+                </div>
+                <div className="mt-4 text-sm font-semibold text-slate-950">
+                  Open Alarm Studio
+                </div>
+                <div className="mt-1 text-xs leading-5 text-slate-500">
+                  Design execution blocks, repeat rules, and sync strategy in the dedicated flow.
+                </div>
+              </button>
+
+              <button
+                type="button"
+                onClick={() => navigate("/my-page")}
+                className="rounded-[28px] border border-slate-200 bg-white/90 p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-sky-300"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-600 text-white">
+                    <UserRound className="h-5 w-5" />
+                  </div>
+                  <ArrowRight className="h-4 w-4 text-slate-400" />
+                </div>
+                <div className="mt-4 text-sm font-semibold text-slate-950">
+                  Open My Page
+                </div>
+                <div className="mt-1 text-xs leading-5 text-slate-500">
+                  Shape identity, strengths, and constraints before you build execution logic.
+                </div>
+              </button>
             </div>
           </div>
 
-          <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
             {TABS.map((tab) => {
               const isActive = tab.id === activeTab;
               const Icon = tab.icon;
@@ -255,8 +315,8 @@ const PlannerPage: React.FC = () => {
                   onClick={() => handleTabChange(tab.id)}
                   className={`rounded-[28px] border px-5 py-4 text-left transition ${
                     isActive
-                      ? "border-sky-500 bg-sky-50 shadow-sm"
-                      : "border-slate-200 bg-slate-50 hover:border-sky-300 hover:bg-white"
+                      ? "border-sky-500 bg-white shadow-sm"
+                      : "border-slate-200 bg-slate-50/90 hover:border-sky-300 hover:bg-white"
                   }`}
                 >
                   <div className="flex items-center gap-2 text-sm font-semibold text-slate-950">
@@ -271,7 +331,7 @@ const PlannerPage: React.FC = () => {
             })}
           </div>
 
-          <div className="mt-5 rounded-[28px] border border-slate-200 bg-slate-50 p-4">
+          <div className="mt-5 rounded-[28px] border border-slate-200 bg-white/80 p-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
               <div>
                 <div className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
@@ -279,9 +339,9 @@ const PlannerPage: React.FC = () => {
                 </div>
                 <div className="mt-2 text-sm text-slate-700">
                   {workspaceLoading
-                    ? "Planner snapshot을 불러오는 중입니다."
+                    ? "Loading planner snapshot."
                     : workspaceError
-                    ? "Planner snapshot을 아직 불러오지 못했습니다. 기존 화면은 그대로 사용할 수 있습니다."
+                    ? "Planner snapshot is temporarily unavailable. The current screen remains usable."
                     : `Active date ${workspace?.active_date ?? activeDate} / source ${
                         workspace?.source.projection_source ?? "unknown"
                       }`}
@@ -291,7 +351,7 @@ const PlannerPage: React.FC = () => {
                 )}
               </div>
 
-              <div className="grid min-w-full gap-3 sm:grid-cols-4 lg:min-w-[420px]">
+              <div className="grid min-w-full gap-3 sm:grid-cols-4 lg:min-w-[440px]">
                 {snapshotCards.map((card) => (
                   <div
                     key={card.label}
@@ -334,7 +394,7 @@ const PlannerPage: React.FC = () => {
                     onClick={clearFocusedTask}
                     className="inline-flex items-center justify-center rounded-2xl border border-amber-300 bg-white px-4 py-2 text-sm font-medium text-amber-900 transition hover:bg-amber-100"
                   >
-                    Clear focus
+                    Clear Focus
                   </button>
                 </div>
               ) : focusMatch ? (
@@ -379,17 +439,27 @@ const PlannerPage: React.FC = () => {
                         onClick={() => handleTabChange("today")}
                         className="inline-flex items-center gap-2 rounded-2xl border border-sky-200 bg-white px-4 py-2 text-sm font-medium text-sky-700 transition hover:border-sky-300 hover:bg-sky-50"
                       >
-                        Today tab
+                        Today Tab
                         <ArrowRight className="h-4 w-4" />
                       </button>
                     )}
-                    {focusMatch.alarmPolicy && activeTab !== "alarm" && (
+                    {focusMatch.alarmPolicy && (
                       <button
                         type="button"
-                        onClick={() => handleTabChange("alarm")}
+                        onClick={() =>
+                          navigate(
+                            buildAddAlarmHref({
+                              baseSearchParams: searchParams,
+                              activeDate,
+                            }),
+                            {
+                              state: location.state,
+                            }
+                          )
+                        }
                         className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
                       >
-                        Alarm tab
+                        Alarm Studio
                         <ArrowRight className="h-4 w-4" />
                       </button>
                     )}
@@ -398,7 +468,7 @@ const PlannerPage: React.FC = () => {
                       onClick={clearFocusedTask}
                       className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:bg-slate-50"
                     >
-                      Clear focus
+                      Clear Focus
                     </button>
                   </div>
                 </div>
@@ -424,7 +494,7 @@ const PlannerPage: React.FC = () => {
                       onClick={clearFocusedTask}
                       className="inline-flex items-center justify-center rounded-2xl border border-amber-300 bg-white px-4 py-2 text-sm font-medium text-amber-900 transition hover:bg-amber-100"
                     >
-                      Clear focus
+                      Clear Focus
                     </button>
                   )}
                 </div>
@@ -434,7 +504,17 @@ const PlannerPage: React.FC = () => {
         </div>
       </section>
 
-      {renderActiveTab()}
+      {activeTab === "deadline" ? (
+        <DeadlinePlannerPage activeDate={activeDate} />
+      ) : (
+        <PlanDayPage
+          activeDate={activeDate}
+          workspace={workspace}
+          focusedTaskUid={focusedTaskUid}
+          workspaceLoading={workspaceLoading}
+          workspaceError={workspaceError}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -1,7 +1,11 @@
 import React, { Suspense, lazy } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
-import { buildPlannerHref, type PlannerTab } from "./utils/plannerRoutes";
+import {
+  buildAddAlarmHref,
+  buildPlannerHref,
+  type PlannerTab,
+} from "./utils/plannerRoutes";
 
 const LoginPage = lazy(() => import("./pages/LoginPage"));
 const MobileLinkPage = lazy(() => import("./pages/MobileLinkPage"));
@@ -25,6 +29,7 @@ const MeditationThemePage = lazy(() => import("./pages/MeditationThemePage"));
 const MeditationSessionPage = lazy(() => import("./pages/MeditationSessionPage"));
 const MeditationRunPage = lazy(() => import("./pages/MeditationRunPage"));
 const PlannerPage = lazy(() => import("./pages/PlannerPage"));
+const AddAlarmPage = lazy(() => import("./pages/AddAlarmPage"));
 const InstallGuidePage = lazy(() => import("./pages/InstallGuidePage"));
 const CheckinRebalancePage = lazy(() => import("./pages/CheckinRebalancePage"));
 const ResistanceEventPage = lazy(() => import("./pages/ResistanceEventPage"));
@@ -59,11 +64,24 @@ const RouteFallback: React.FC = () => (
   </div>
 );
 
-const LegacyPlannerRedirect: React.FC<{ tab?: PlannerTab }> = ({ tab = "alarm" }) => {
+const LegacyPlannerRedirect: React.FC<{ tab?: Exclude<PlannerTab, "alarm"> }> = ({
+  tab = "today",
+}) => {
   const location = useLocation();
   return (
     <Navigate
       to={buildPlannerHref(tab, { baseSearchParams: location.search })}
+      replace
+      state={location.state}
+    />
+  );
+};
+
+const LegacyAlarmRedirect: React.FC = () => {
+  const location = useLocation();
+  return (
+    <Navigate
+      to={buildAddAlarmHref({ baseSearchParams: location.search })}
       replace
       state={location.state}
     />
@@ -81,7 +99,8 @@ export default function AppRoutes() {
         <Route path="/plan/day" element={<LegacyPlannerRedirect tab="today" />} />
         <Route path="/profile-setup" element={<MyPage />} />
         <Route path="/my-page" element={<MyPage />} />
-        <Route path="/add-alarm" element={<LegacyPlannerRedirect tab="alarm" />} />
+        <Route path="/add-alarm" element={<AddAlarmPage />} />
+        <Route path="/planner/alarm" element={<LegacyAlarmRedirect />} />
         <Route path="/deadline-planner" element={<LegacyPlannerRedirect tab="deadline" />} />
         <Route path="/signal-inbox" element={<SignalInboxPage />} />
         <Route path="/morning-brief" element={<MorningBriefPage />} />
@@ -125,6 +144,7 @@ export default function AppRoutes() {
         <Route path="/meditation/theme" element={<MeditationThemePage />} />
         <Route path="/meditation/session" element={<MeditationSessionPage />} />
         <Route path="/meditation/run" element={<MeditationRunPage />} />
+        <Route path="/install/android" element={<InstallGuidePage />} />
         <Route path="/install-guide" element={<InstallGuidePage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/frontend/src/services/authSession.ts
+++ b/frontend/src/services/authSession.ts
@@ -1,0 +1,80 @@
+import { resolveBackendUrl } from "@/config/api";
+
+export type BackendAuthUser = {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+  photo_url?: string | null;
+};
+
+type BackendMeResponse = {
+  authenticated?: boolean;
+  user?: BackendAuthUser | null;
+};
+
+const AUTH_ME_PATH = "/api/auth/me";
+const AUTH_REFRESH_PATH = "/api/auth/refresh";
+
+let refreshPromise: Promise<boolean> | null = null;
+
+const parseJson = async <T,>(response: Response): Promise<T | null> => {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    return null;
+  }
+};
+
+const fetchBackendMe = async (): Promise<BackendAuthUser | null> => {
+  const response = await fetch(resolveBackendUrl(AUTH_ME_PATH), {
+    credentials: "include",
+  });
+  if (!response.ok) {
+    return null;
+  }
+  const payload = await parseJson<BackendMeResponse>(response);
+  if (payload?.authenticated && payload.user?.id) {
+    return payload.user;
+  }
+  return null;
+};
+
+export const refreshBackendSession = async (): Promise<boolean> => {
+  if (refreshPromise) {
+    return refreshPromise;
+  }
+
+  refreshPromise = (async () => {
+    try {
+      const response = await fetch(resolveBackendUrl(AUTH_REFRESH_PATH), {
+        method: "POST",
+        credentials: "include",
+      });
+      return response.ok;
+    } catch {
+      return false;
+    } finally {
+      refreshPromise = null;
+    }
+  })();
+
+  return refreshPromise;
+};
+
+export const loadBackendSessionUser = async (
+  options?: { allowRefresh?: boolean }
+): Promise<BackendAuthUser | null> => {
+  const allowRefresh = options?.allowRefresh ?? true;
+  const directUser = await fetchBackendMe();
+  if (directUser || !allowRefresh) {
+    return directUser;
+  }
+
+  const refreshed = await refreshBackendSession();
+  if (!refreshed) {
+    return null;
+  }
+
+  return fetchBackendMe();
+};
+

--- a/frontend/src/utils/plannerRoutes.test.ts
+++ b/frontend/src/utils/plannerRoutes.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAddAlarmHref,
+  buildPlannerHref,
+  normalizePlannerTab,
+} from "./plannerRoutes";
+
+describe("plannerRoutes", () => {
+  it("defaults planner navigation to the today workspace", () => {
+    expect(normalizePlannerTab(null)).toBe("today");
+    expect(buildPlannerHref("today", { activeDate: "2026-03-14" })).toBe(
+      "/planner?active_date=2026-03-14"
+    );
+  });
+
+  it("preserves shared search params when moving inside planner", () => {
+    expect(
+      buildPlannerHref("deadline", {
+        activeDate: "2026-03-14",
+        baseSearchParams: "?task_uid=item-1&source=mobile_calendar_item&tab=alarm",
+      })
+    ).toBe(
+      "/planner?task_uid=item-1&source=mobile_calendar_item&tab=deadline&active_date=2026-03-14"
+    );
+  });
+
+  it("removes planner tabs when building the dedicated add alarm route", () => {
+    expect(
+      buildAddAlarmHref({
+        baseSearchParams: "?tab=deadline&active_date=2026-03-14&task_uid=item-1",
+      })
+    ).toBe("/add-alarm?active_date=2026-03-14&task_uid=item-1");
+  });
+});

--- a/frontend/src/utils/plannerRoutes.ts
+++ b/frontend/src/utils/plannerRoutes.ts
@@ -3,18 +3,21 @@ import { todayInKoreaIso } from "./koreaTime";
 export type PlannerTab = "alarm" | "deadline" | "today";
 
 export const PLANNER_PATH = "/planner";
+export const ADD_ALARM_PATH = "/add-alarm";
 
-export const DEFAULT_PLANNER_TAB: PlannerTab = "alarm";
+export const DEFAULT_PLANNER_TAB: PlannerTab = "today";
 
 const ISO_DATE_RX = /^\d{4}-\d{2}-\d{2}$/;
 
-type BuildPlannerHrefOptions = {
+type BuildHrefOptions = {
   activeDate?: string | null;
   baseSearchParams?: string | URLSearchParams | null;
 };
 
 export const normalizePlannerTab = (value: string | null | undefined): PlannerTab =>
-  value === "deadline" || value === "today" ? value : DEFAULT_PLANNER_TAB;
+  value === "alarm" || value === "deadline" || value === "today"
+    ? value
+    : DEFAULT_PLANNER_TAB;
 
 export const normalizePlannerActiveDate = (
   value: string | null | undefined,
@@ -24,9 +27,24 @@ export const normalizePlannerActiveDate = (
   return trimmed && ISO_DATE_RX.test(trimmed) ? trimmed : fallback;
 };
 
+const applyActiveDate = (
+  params: URLSearchParams,
+  activeDate: string | null | undefined
+) => {
+  if (activeDate === undefined) return;
+
+  const normalized = activeDate ? normalizePlannerActiveDate(activeDate, "") : "";
+  if (normalized) {
+    params.set("active_date", normalized);
+    return;
+  }
+
+  params.delete("active_date");
+};
+
 export const buildPlannerHref = (
   tab: PlannerTab = DEFAULT_PLANNER_TAB,
-  options: BuildPlannerHrefOptions = {}
+  options: BuildHrefOptions = {}
 ): string => {
   const params = new URLSearchParams(options.baseSearchParams ?? undefined);
 
@@ -36,17 +54,17 @@ export const buildPlannerHref = (
     params.set("tab", tab);
   }
 
-  if (options.activeDate !== undefined) {
-    const normalized = options.activeDate
-      ? normalizePlannerActiveDate(options.activeDate, "")
-      : "";
-    if (normalized) {
-      params.set("active_date", normalized);
-    } else {
-      params.delete("active_date");
-    }
-  }
+  applyActiveDate(params, options.activeDate);
 
   const search = params.toString();
   return search ? `${PLANNER_PATH}?${search}` : PLANNER_PATH;
+};
+
+export const buildAddAlarmHref = (options: BuildHrefOptions = {}): string => {
+  const params = new URLSearchParams(options.baseSearchParams ?? undefined);
+  params.delete("tab");
+  applyActiveDate(params, options.activeDate);
+
+  const search = params.toString();
+  return search ? `${ADD_ALARM_PATH}?${search}` : ADD_ALARM_PATH;
 };


### PR DESCRIPTION
## Summary
- centralize frontend auth session hydration and refresh handling
- retry protected planner and calendar requests after backend session refresh
- complete install bootstrap guidance across alarm, plan-day, and install-guide flows
- replace external QR rendering with in-app QR generation and remove noisy install prompt logging

## Latest update
- split Planner and Add Alarm into dedicated product flows, with `/add-alarm` promoted to its own route
- upgrade the shared header and bottom navigation into a premium control-surface shell
- redesign Planner, Alarm Studio, Deadline, and My Page surfaces with clearer control-deck cards and production-level CTAs
- add route coverage for the new planner and add-alarm navigation behavior

## Validation
- npm --prefix frontend run type-check
- npm --prefix frontend run build
- npm run type-check
